### PR TITLE
Simplify grid-item classes and clean up static vs. dynamic attributes

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -25,9 +25,8 @@ let categories = Object.keys(cardsByCategory).map(category => {
 onMounted(() => {
   categories.forEach(category => {
     let gridSelector = `.grid-${category['slug']}`
-    let gridItemSelector = `.grid-item-${category['slug']}`
     new $Masonry(gridSelector, {
-      itemSelector: gridItemSelector,
+      itemSelector: '.grid-item',
       columnWidth: 300,
     })
   })
@@ -37,9 +36,9 @@ onMounted(() => {
 <template>
   <div v-for="category in categories">
     <h1 class="title is-3">{{ category['name'] }}</h1>
-    <div :class="'mb-3 grid-' + category['slug']">
+    <div class="mb-3" :class="'grid-' + category['slug']">
       <div
-        :class="'card clamp mb-5 grid-item-' + category['slug']"
+        class="card clamp mb-5 grid-item"
         v-for="card in cardsByCategory[category['name']]"
       >
         <div v-if="card['image']" class="card-image">


### PR DESCRIPTION
This PR cleans up HTML template code by using `:bind` only for dynamic class names, alongside just `bind` for static class names. It turns out this works just fine! I don't know why it didn't seem to work on my first pass.

I also realized that only the Masonry grids themselves (parent divs) need unique class selectors. Grid items can all use the `grid-item` class regardless of which grid they belong to, and I think it's better (more portable) to keep these more general because it may help with SASS styling later down the road if needed.