### PR TITLE
Optionally load item's full view content from a Vue component

### DIFF
--- a/assets/items.js
+++ b/assets/items.js
@@ -89,6 +89,7 @@ export default [
   },
   {
     type: 'general',
+    slug: 'querying-daymet-daily-precipitation',
     image: '/previews/data-preview-5.png',
     imageAlt: 'temp map of alaska',
     title:

--- a/components/Item.vue
+++ b/components/Item.vue
@@ -10,6 +10,8 @@ const props = defineProps<{
   fullView?: string
 }>()
 
+import { slugToCamelCase } from '~/utils/slugs'
+
 const isSmall = computed<boolean>(() => {
   return props.type === 'small'
 })
@@ -20,11 +22,13 @@ const showReadMore = computed<boolean>(() => {
   if (props.fullView !== undefined) {
     return true
   }
-  const component = resolveComponent(props.slug)
-  if (typeof component === 'string') {
-    return false
-  } else {
+
+  let camelCaseString = slugToCamelCase(props.slug)
+  let vueComponents = getCurrentInstance()?.appContext.components
+  if (vueComponents?.hasOwnProperty(camelCaseString)) {
     return true
+  } else {
+    return false
   }
 })
 const fullViewLink = computed<string>(() => {

--- a/components/Item.vue
+++ b/components/Item.vue
@@ -13,8 +13,19 @@ const props = defineProps<{
 const isSmall = computed<boolean>(() => {
   return props.type === 'small'
 })
-const hasFullView = computed<boolean>(() => {
-  return props.fullView !== undefined && props.slug !== undefined
+const showReadMore = computed<boolean>(() => {
+  if (props.slug === undefined) {
+    return false
+  }
+  if (props.fullView !== undefined) {
+    return true
+  }
+  const component = resolveComponent(props.slug)
+  if (typeof component === 'string') {
+    return false
+  } else {
+    return true
+  }
 })
 const fullViewLink = computed<string>(() => {
   return '/item/' + props.slug
@@ -36,7 +47,7 @@ const fullViewLink = computed<string>(() => {
         <div class="content">
           <h3 class="title is-4" v-html="title"></h3>
           <p v-html="blurb" />
-          <div v-if="hasFullView" class="mb-4">
+          <div v-if="showReadMore" class="mb-4">
             <NuxtLink :to="fullViewLink">Read more</NuxtLink>
           </div>
           <span v-for="tag in tags" class="tag is-dark mb-1">{{ tag }}</span>

--- a/components/global/QueryingDaymetDailyPrecipitation.vue
+++ b/components/global/QueryingDaymetDailyPrecipitation.vue
@@ -1,0 +1,26 @@
+<script lang="ts" setup></script>
+
+<template>
+  <h3 class="title is-3">Excelsior!</h3>
+
+  <p class="mb-3">This content is loaded from a component file.</p>
+
+  <p class="mb-3">
+    When visiting the URL for an item, this page first checks if a component
+    file exists that corresponds to the item's slug. If so, it will display that
+    component.
+  </p>
+
+  <p class="mb-3">
+    If no component file exists for the item's slug, this page will instead
+    display the item's "fullView" field if it exists.
+  </p>
+
+  <p>
+    If neither a component file nor "fullView" field exists for an item, no
+    "Read more" link is displayed for the item. If a user somehow lands at this
+    URL anyway, they get an "item not found" message.
+  </p>
+</template>
+
+<style scoped></style>

--- a/pages/full.vue
+++ b/pages/full.vue
@@ -3,16 +3,48 @@ definePageMeta({
   layout: 'full',
 })
 
+import type { ConcreteComponent } from 'vue'
+import { getCurrentInstance } from 'vue'
 import items from '~/assets/items'
 
 const route = useRoute()
 let slug = route.params.slug
 let item = items.find(item => item.slug === slug)
+let component: ConcreteComponent | string
+
+const componentFileExists = computed<boolean>(() => {
+  let slugString = slug.toString()
+
+  // Validate that slug is not empty and contains only expected characters.
+  if (slugString === '' || !slugString.match(/^[a-z0-9-]+$/)) {
+    return false
+  }
+
+  // Convert slug string from lowercase-with-dashes style to the CamelCase
+  // style used for Vue components.
+  let camelCaseString = slugString
+    .split('-')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join('')
+
+  let vueComponents = getCurrentInstance()?.appContext.components
+  if (vueComponents?.hasOwnProperty(camelCaseString)) {
+    component = resolveComponent(camelCaseString)
+    return true
+  } else {
+    return false
+  }
+})
 </script>
 
 <template>
-  <h1 class="title is-3" v-html="item?.['title']"></h1>
-  <div v-html="item?.['fullView'] ?? ''" />
+  <div v-if="componentFileExists">
+    <Component :is="component" />
+  </div>
+  <div v-else-if="item?.fullView">
+    <div v-html="item?.fullView"></div>
+  </div>
+  <div v-else>Item not found.</div>
 </template>
 
 <style scoped></style>

--- a/pages/full.vue
+++ b/pages/full.vue
@@ -6,6 +6,7 @@ definePageMeta({
 import type { ConcreteComponent } from 'vue'
 import { getCurrentInstance } from 'vue'
 import items from '~/assets/items'
+import { validSlug, slugToCamelCase } from '~/utils/slugs'
 
 const route = useRoute()
 let slug = route.params.slug
@@ -14,18 +15,10 @@ let component: ConcreteComponent | string
 
 const componentFileExists = computed<boolean>(() => {
   let slugString = slug.toString()
-
-  // Validate that slug is not empty and contains only expected characters.
-  if (slugString === '' || !slugString.match(/^[a-z0-9-]+$/)) {
+  if (!validSlug(slugString)) {
     return false
   }
-
-  // Convert slug string from lowercase-with-dashes style to the CamelCase
-  // style used for Vue components.
-  let camelCaseString = slugString
-    .split('-')
-    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-    .join('')
+  let camelCaseString = slugToCamelCase(slugString)
 
   let vueComponents = getCurrentInstance()?.appContext.components
   if (vueComponents?.hasOwnProperty(camelCaseString)) {

--- a/utils/slugs.ts
+++ b/utils/slugs.ts
@@ -1,0 +1,17 @@
+export const validSlug = (slug: string) => {
+  // Validate that slug is not empty and contains only expected characters.
+  if (slug === '' || !slug.match(/^[a-z0-9-]+$/)) {
+    return false
+  } else {
+    return true
+  }
+}
+
+export const slugToCamelCase = (slug: string) => {
+  // Convert slug string from lowercase-with-dashes style to the CamelCase
+  // style used for Vue components.
+  return slug
+    .split('-')
+    .map((word: string) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join('')
+}


### PR DESCRIPTION
This PR implements one way (and the only way I've found) to optionally & dynamically load an item's "full view" display from a file.

The motivation here is to be able to populate the full view for an item with things like embedded Leaflet maps, tables, interactive widgets, and general **_bespokery_**, and to do this in a sane, maintainable, and version-controlled way. Without this functionality, we were faced with the possibility of implementing complex full view displays as giant blobs of HTML inside items' `fullView` fields, which would start out gnarly in the simplest of cases and only get worse after that.

This PR works by taking the item slug from the URL (e.g., `querying-daymet-daily-precipitation`), converting that into the camel case style used by Vue components (e.g., `QueryingDaymetDailyPrecipitation`), and then checking to see if a global component with that name exists. If so, the found component is loaded into the `full.vue` page. If not, and if a `fullView` HTML field exists for the item, that is loaded into the `full.vue` page instead. If neither a component file nor `fullView` field exists for the item, no "Read more" link is displayed.

Dynamically loading components in this way requires that the components live in the global component space, otherwise Vue is not aware that these components exist until it tries (and fails) to load them. Fortunately, all that is required to make Vue components global is to place them in the `global` component subdirectory.

To test, load the app and observe that there are now two items with "Read more" links:

- "Future precipitation map & web services" (full view implemented with `fullView` field, same as before)
- "Querying Daymet daily precipitation data using polygons from the SNAP Data API" (full view implemented with a component file)

Make sure each of the two "Read more" links works as expected. That's it, basically!