### PR TITLE
Remove categorization and item duplication, and also remove search bar centering attempts

### DIFF
--- a/components/Search.vue
+++ b/components/Search.vue
@@ -43,7 +43,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <input id="autoComplete" class="foobar" />
+  <input id="autoComplete" class="ml-2" />
 </template>
 
 <style lang="scss" scoped>
@@ -53,9 +53,5 @@ onMounted(() => {
 /* Hide results list since we are showing results as cards instead. */
 :global(ul[id^='autoComplete_list']) {
   display: none;
-}
-#autoComplete {
-  display: block;
-  margin: 0 auto;
 }
 </style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -10,42 +10,15 @@ const store = useStore()
 
 const items = computed<any[]>(() => store.filteredItems)
 const searchActive = computed(() => store.searchActive)
-const itemsByTag = ref({} as ItemsByTag)
-const tags = ref(new Array<Tag>())
 
 const populatePage = () => {
-  itemsByTag.value = {}
-  items.value.forEach((item: Item) => {
-    item.tags?.forEach((tag: string) => {
-      if (!itemsByTag.value.hasOwnProperty(tag)) {
-        itemsByTag.value[tag] = new Array<Item>()
-      }
-      itemsByTag.value[tag].push(item)
-    })
-  })
-  tags.value = Object.keys(itemsByTag.value).map(tag => {
-    return {
-      name: tag,
-      slug: tag.toLowerCase().replaceAll(' ', '-'),
-    }
-  })
   setTimeout(() => {
     let gridItemSelector = '.grid-item'
     let columnWidth = 352
-    if (!store.searchActive) {
-      tags.value.forEach(tag => {
-        let gridSelector = `.grid-${tag['slug']}`
-        new $Masonry(gridSelector, {
-          itemSelector: gridItemSelector,
-          columnWidth: columnWidth,
-        })
-      })
-    } else if (items.value.length > 0) {
-      new $Masonry('.grid', {
-        itemSelector: gridItemSelector,
-        columnWidth: columnWidth,
-      })
-    }
+    new $Masonry('.grid', {
+      itemSelector: gridItemSelector,
+      columnWidth: columnWidth,
+    })
   }, 0)
 }
 
@@ -61,42 +34,23 @@ watch([items, searchActive], async () => {
 <template>
   <section class="section dark">
     <div class="container">
-      <Search />
-      <div v-if="!store.searchActive" v-for="tag in tags">
-        <h1 class="title is-3">{{ tag['name'] }}</h1>
-        <div class="mb-6" :class="'grid-' + tag['slug']">
-          <div v-for="item in itemsByTag[tag['name']]" class="grid-item">
-            <Item
-              :type="item.type"
-              :image="item.image"
-              :imageAlt="item.imageAlt"
-              :title="item.title"
-              :blurb="item.blurb"
-              :tags="item.tags"
-              :slug="item.slug"
-              :fullView="item.fullView"
-            />
-          </div>
+      <Search class="mb-6" />
+      <div v-if="items.length > 0" class="mb-6 grid">
+        <div v-for="item in items" class="grid-item">
+          <Item
+            :type="item.type"
+            :image="item.image"
+            :imageAlt="item.imageAlt"
+            :title="item.title"
+            :blurb="item.blurb"
+            :tags="item.tags"
+            :slug="item.slug"
+            :fullView="item.fullView"
+          />
         </div>
       </div>
-      <div v-else>
-        <div v-if="items.length > 0" class="mb-6 grid">
-          <div v-for="item in items" class="grid-item">
-            <Item
-              :type="item.type"
-              :image="item.image"
-              :imageAlt="item.imageAlt"
-              :title="item.title"
-              :blurb="item.blurb"
-              :tags="item.tags"
-              :slug="item.slug"
-              :fullView="item.fullView"
-            />
-          </div>
-        </div>
-        <div v-else class="has-text-centered">
-          <h1 class="title is-4">No results found.</h1>
-        </div>
+      <div v-else class="has-text-centered">
+        <h1 class="title is-4">No results found.</h1>
       </div>
     </div>
   </section>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -13,6 +13,9 @@ const searchActive = computed(() => store.searchActive)
 
 const populatePage = () => {
   setTimeout(() => {
+    if (items.value.length === 0) {
+      return
+    }
     let gridItemSelector = '.grid-item'
     let columnWidth = 352
     new $Masonry('.grid', {
@@ -49,7 +52,7 @@ watch([items, searchActive], async () => {
           />
         </div>
       </div>
-      <div v-else class="has-text-centered">
+      <div v-else class="ml-2">
         <h1 class="title is-4">No results found.</h1>
       </div>
     </div>

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -8,12 +8,3 @@ interface Item {
   slug?: string
   fullView?: string
 }
-
-interface ItemsByTag {
-  [key: string]: Item[]
-}
-
-interface Tag {
-  name: string
-  slug: string
-}


### PR DESCRIPTION
This PR removes categorization by tag (and item duplication) from the front page. It also removes a couple custom TypeScript types that are no longer needed now that this functionality has been removed.

I've also tweaked the layout of the search system a little bit, too, to remove my attempts at centering the search bar and "No results..." message. The centering had gotten a bit wonky and unpredictable at different resolutions, so I figure it's better to align these to the left for now.

To test, load the app, make sure the items are laid out well + not duplicated, and everything continues to look good when using the search system.