### PR TITLE
Add count of matched items below search bar

### DIFF
--- a/components/ResultsCount.vue
+++ b/components/ResultsCount.vue
@@ -1,0 +1,32 @@
+<script lang="ts" setup>
+import { useStore } from '~/stores/store'
+const store = useStore()
+const resultsCount = computed(() => store.filteredItems.length)
+const searchActive = computed(() => store.searchActive)
+const totalItemCount = computed(() => store.totalItemCount)
+</script>
+
+<template>
+  <div v-if="searchActive">
+    <div v-if="resultsCount > 0">
+      <p class="ml-2 mt-2">
+        Showing
+        <strong class="has-text-white">{{ resultsCount }}</strong>
+        <span v-if="resultsCount > 1"> matches</span>
+        <span v-else> match</span>
+        out of
+        <strong class="has-text-white">{{ totalItemCount }}</strong>
+        possible items.
+      </p>
+    </div>
+    <div v-else>
+      <p class="ml-2 mt-2">
+        No matches found out of
+        <strong class="has-text-white">{{ totalItemCount }}</strong>
+        possible items.
+      </p>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped></style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -12,11 +12,8 @@ const items = computed<any[]>(() => store.filteredItems)
 const searchActive = computed(() => store.searchActive)
 const itemsByTag = ref({} as ItemsByTag)
 const tags = ref(new Array<Tag>())
-const totalItemCount = ref()
-const resultsCount = ref()
 
 const populatePage = () => {
-  resultsCount.value = items.value.length
   itemsByTag.value = {}
   items.value.forEach((item: Item) => {
     item.tags?.forEach((tag: string) => {
@@ -53,7 +50,6 @@ const populatePage = () => {
 }
 
 onMounted(() => {
-  totalItemCount.value = items.value.length
   populatePage()
 })
 
@@ -66,26 +62,7 @@ watch([items, searchActive], async () => {
   <section class="section dark">
     <div class="container">
       <Search />
-      <div v-if="searchActive">
-        <div v-if="resultsCount > 0">
-          <p class="ml-2 mt-2">
-            Showing
-            <strong class="has-text-white">{{ resultsCount }}</strong>
-            <span v-if="resultsCount > 1"> matches</span>
-            <span v-else> match</span>
-            out of
-            <strong class="has-text-white">{{ totalItemCount }}</strong>
-            possible items.
-          </p>
-        </div>
-        <div v-else>
-          <p class="ml-2 mt-2">
-            No matches found out of
-            <strong class="has-text-white">{{ totalItemCount }}</strong>
-            possible items.
-          </p>
-        </div>
-      </div>
+      <ResultsCount />
       <div v-if="!store.searchActive" v-for="tag in tags">
         <h1 class="title is-3">{{ tag['name'] }}</h1>
         <div class="mb-6" :class="'grid-' + tag['slug']">

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -12,8 +12,11 @@ const items = computed<any[]>(() => store.filteredItems)
 const searchActive = computed(() => store.searchActive)
 const itemsByTag = ref({} as ItemsByTag)
 const tags = ref(new Array<Tag>())
+const totalItemCount = ref()
+const resultsCount = ref()
 
 const populatePage = () => {
+  resultsCount.value = items.value.length
   itemsByTag.value = {}
   items.value.forEach((item: Item) => {
     item.tags?.forEach((tag: string) => {
@@ -50,6 +53,7 @@ const populatePage = () => {
 }
 
 onMounted(() => {
+  totalItemCount.value = items.value.length
   populatePage()
 })
 
@@ -62,6 +66,26 @@ watch([items, searchActive], async () => {
   <section class="section dark">
     <div class="container">
       <Search />
+      <div v-if="searchActive">
+        <div v-if="resultsCount > 0">
+          <p class="ml-2 mt-2">
+            Showing
+            <strong class="has-text-white">{{ resultsCount }}</strong>
+            <span v-if="resultsCount > 1"> matches</span>
+            <span v-else> match</span>
+            out of
+            <strong class="has-text-white">{{ totalItemCount }}</strong>
+            possible items.
+          </p>
+        </div>
+        <div v-else>
+          <p class="ml-2 mt-2">
+            No matches found out of
+            <strong class="has-text-white">{{ totalItemCount }}</strong>
+            possible items.
+          </p>
+        </div>
+      </div>
       <div v-if="!store.searchActive" v-for="tag in tags">
         <h1 class="title is-3">{{ tag['name'] }}</h1>
         <div class="mb-6" :class="'grid-' + tag['slug']">
@@ -93,9 +117,6 @@ watch([items, searchActive], async () => {
               :fullView="item.fullView"
             />
           </div>
-        </div>
-        <div v-else class="has-text-centered">
-          <h1 class="title is-4">No results found.</h1>
         </div>
       </div>
     </div>

--- a/stores/store.ts
+++ b/stores/store.ts
@@ -2,11 +2,13 @@ import { defineStore } from 'pinia'
 import items from '~/assets/items'
 
 export const useStore = defineStore('store', () => {
+  const totalItemCount = ref(items.length)
   const filteredItems = ref(items)
   const searchActive = ref(false)
 
   return {
     filteredItems,
     searchActive,
+    totalItemCount,
   }
 })


### PR DESCRIPTION
This PR adds the following message below the search bar when search mode is engaged:

> Showing __ matches out of __ possible items.

I've also moved the "No results found" message into this new system, so when search mode is engaged and no results are found, it says:

> No matches found out of __ possible items.

To test, run the app and confirm that the message only shows when search mode is engaged and the text reads how you expect depending on the number of results, singular/plural, etc.