### PR TITLE
Switch to light background

### DIFF
--- a/assets/styles/_variables.scss
+++ b/assets/styles/_variables.scss
@@ -1,7 +1,11 @@
+// Variables to be used in components, etc.
+// If these are the same name as Bulma variables,
+// it'll override them.
+$family-sans-serif: "Archivo", sans-serif;
 
-// Set your brand colors
-
-$pink: #FA7C91;
-$beige-light: #D0D1CD;
 $black: #102030;
 $white: #fff8f0;
+$gray: #64686a;
+$gray-darker: #34383a;
+
+$link: #D60A2C;

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -1,34 +1,6 @@
 @charset "utf-8";
 
 @import url('https://fonts.googleapis.com/css2?family=Archivo:wght@300;400;600;700;800;900&family=IBM+Plex+Mono:wght@300;400;500&display=swap');
-// @import url('~/assets/styles/_variables.scss');
-
-// Update Bulma's global variables
-$family-sans-serif: "Archivo", sans-serif;
-$text: $beige-light;
-$link: $pink;
-
-// Update some of Bulma's component variables
-$body-background-color: $white;
 
 // Import the rest of Bulma
 @import "~/node_modules/bulma/bulma.sass";
-
-// Specific overrides
-.title {
-	color: $text;
-}
-
-.card {
-	color: $black;
-	.tag {
-		margin-right: 0.25rem;
-	}
-	.title {
-		color: $black;
-	}
-}
-
-.dark {
-  background-color: $black;
-}

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -16,9 +16,9 @@
 
 <style lang="scss" scoped>
 .brand {
-  color: $white;
+  color: $black;
   h1 {
-    color: #ccc;
+    color: $gray;
     margin-left: 4rem;
     margin-bottom: -2.2rem;
     font-weight: 700;

--- a/components/HeaderBanner.vue
+++ b/components/HeaderBanner.vue
@@ -13,7 +13,7 @@
 
   padding: 0.75rem;
 
-  background-color: #666;
+  background-color: $gray;
 
   color: #fff;
   font-size: 0.8rem;

--- a/components/Item.vue
+++ b/components/Item.vue
@@ -54,7 +54,7 @@ const fullViewLink = computed<string>(() => {
           <div v-if="showReadMore" class="mb-4">
             <NuxtLink :to="fullViewLink">Read more</NuxtLink>
           </div>
-          <span v-for="tag in tags" class="tag is-dark mb-1">{{ tag }}</span>
+          <span v-for="tag in tags" class="tag mb-1">{{ tag }}</span>
         </div>
       </div>
     </div>

--- a/components/ResultsCount.vue
+++ b/components/ResultsCount.vue
@@ -11,18 +11,18 @@ const totalItemCount = computed(() => store.totalItemCount)
     <div v-if="resultsCount > 0">
       <p class="ml-2 mt-2">
         Showing
-        <strong class="has-text-white">{{ resultsCount }}</strong>
+        <strong>{{ resultsCount }}</strong>
         <span v-if="resultsCount > 1"> matches</span>
         <span v-else> match</span>
         out of
-        <strong class="has-text-white">{{ totalItemCount }}</strong>
+        <strong>{{ totalItemCount }}</strong>
         possible items.
       </p>
     </div>
     <div v-else>
       <p class="ml-2 mt-2">
         No matches found out of
-        <strong class="has-text-white">{{ totalItemCount }}</strong>
+        <strong>{{ totalItemCount }}</strong>
         possible items.
       </p>
     </div>


### PR DESCRIPTION
This PR switches us to a light background design.  It also does a little cleanup/clarification of what/where custom variables and/or Bulma overrides are doing in the build process.

 * We should use variables for colors in components so that we can be consistent.
 * Define custom variables in `assets/styles/_variables.scss`
 * Variables defined there will override Bulma variable names, so this is also where Bulma overrides go.
 * You can't use a Bulma variable in a component unless you define it here.

Test = load the page + see light background!