### PR TITLE
Replace item Bulma card styling with custom horizontal styling

### DIFF
--- a/assets/styles/_variables.scss
+++ b/assets/styles/_variables.scss
@@ -4,7 +4,9 @@
 $family-sans-serif: "Archivo", sans-serif;
 
 $black: #102030;
+$white-lighter: #ffffff;
 $white: #fff8f0;
+$gray-lighter: #cccccc;
 $gray: #64686a;
 $gray-darker: #34383a;
 

--- a/components/Item.vue
+++ b/components/Item.vue
@@ -37,28 +37,24 @@ const fullViewLink = computed<string>(() => {
 </script>
 
 <template>
-  <div class="card">
-    <div v-if="isSmall" class="card-content">
-      <h5 class="title is-5" v-html="title"></h5>
-    </div>
-    <div v-else>
-      <div v-if="image" class="card-image">
-        <figure class="image is-4by3">
-          <img :src="image" :alt="imageAlt" />
-        </figure>
+  <div class="p-4">
+    <div>
+      <img :src="image" :alt="imageAlt" class="is-pulled-right mb-4 ml-4" />
+      <h3 class="title is-4 mt-0" v-html="title"></h3>
+      <p v-if="blurb" v-html="blurb" class="mb-4" />
+      <div v-if="showReadMore" class="mb-4">
+        <NuxtLink :to="fullViewLink">Read more</NuxtLink>
       </div>
-      <div class="card-content">
-        <div class="content">
-          <h3 class="title is-4" v-html="title"></h3>
-          <p v-html="blurb" />
-          <div v-if="showReadMore" class="mb-4">
-            <NuxtLink :to="fullViewLink">Read more</NuxtLink>
-          </div>
-          <span v-for="tag in tags" class="tag mb-1">{{ tag }}</span>
-        </div>
-      </div>
+      <span v-for="tag in tags" class="tag is-dark mt-1 mb-1 mr-1">{{
+        tag
+      }}</span>
     </div>
   </div>
 </template>
 
-<style scoped></style>
+<style scoped>
+img {
+  max-width: 200px;
+  height: auto;
+}
+</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -17,7 +17,7 @@ const populatePage = () => {
       return
     }
     let gridItemSelector = '.grid-item'
-    let columnWidth = 352
+    let columnWidth = 550
     new $Masonry('.grid', {
       itemSelector: gridItemSelector,
       columnWidth: columnWidth,
@@ -37,10 +37,9 @@ watch([items, searchActive], async () => {
 <template>
   <section class="section dark">
     <div class="container">
-
       <Search class="mb-6" />
       <ResultsCount />
-      
+
       <div v-if="items.length > 0" class="mb-6 grid">
         <div v-for="item in items" class="grid-item">
           <Item
@@ -55,16 +54,16 @@ watch([items, searchActive], async () => {
           />
         </div>
       </div>
-      <div v-else class="ml-2">
-        <h1 class="title is-4">No results found.</h1>
-      </div>
     </div>
   </section>
 </template>
 
 <style lang="scss" scoped>
 .grid-item {
-  max-width: 332px;
+  width: 530px;
   margin: 10px;
+  border: 1px solid $gray-lighter;
+  border-radius: 5px;
+  background-color: $white-lighter;
 }
 </style>


### PR DESCRIPTION
This PR removes all of the Bulma card styling classes from the `Item` template HTML and replaces it with horizontal styling via custom CSS + Bulma helper classes.

I've also removed the old "No results found." message that has been superseded by our new "No matches found out of __ possible items." message. It must have snuck back in during a merge/rebase conflict resolution.

To test, load the app and verify that the items are horizontally oriented and that Masonry places them side-by-side at medium-to-wide browser resolutions. And that everything looks good generally, of course.