### PR TITLE
Attempt to embed Jupyter notebook into item component

### DIFF
--- a/assets/items.js
+++ b/assets/items.js
@@ -107,4 +107,11 @@ export default [
     title: `Historical + near-real-time <a href="https://earthmaps.io/fire/" >wildfire and related research data</a>`,
     tags: ['API', 'Wildfire'],
   },
+  {
+    type: 'general',
+    slug: 'modified-berggren-frost-depth-calculator',
+    title: `Modified Berggren frost depth calculator`,
+    blurb: `In this notebook, we use temperature and degree days data from SNAP's Data API to calculate the modified Berggren frost depth.`,
+    tags: ['API', 'Temperature', 'Degree Days', 'Notebook'],
+  },
 ]

--- a/components/global/ModifiedBerggrenFrostDepthCalculator.vue
+++ b/components/global/ModifiedBerggrenFrostDepthCalculator.vue
@@ -1,0 +1,14 @@
+<script lang="ts" setup></script>
+
+<template>
+  <h1 class="title is-1">Modified Berggren frost depth calculator</h1>
+  <iframe
+    src="https://ua-snap.github.io/ardac-notebooks/lab/?kernel=python&toolbar=1&path=%2Ffrost_depth%2FModified+Berggren+Frost+Depth.ipynb"
+    width="100%"
+    height="1000px"
+    id="notebook"
+  >
+  </iframe>
+</template>
+
+<style scoped></style>


### PR DESCRIPTION
This PR is the result of my exploration of embedding a JupyterLite notebook inside a Vue component (or web page, generally). It doesn't work great, but as far as I can tell this is the best we can do. I've set this PR to draft mode because it is likely a dead end that we won't want to merge.

I started out by searching how to embed JupyterLite notebooks into a web page. The resources I found ([example](https://blog.jupyter.org/jupyter-everywhere-f8151c2cc6e8)) showed how to embed an interactive JupyterLite shell (REPL) into a page, but not an already-made notebook. There was no magic here, just an HTML iframe.

If iframes are good enough for an interactive Python shell, I figured I'd try using a similar approach to embed our JupyterLite notebooks directly into a Vue component.

The good news:
- It does actually work! Executing the notebook works just fine and produces the expected outputs.
- I discovered that you can use the `path` HTTP GET parameter to load specific notebooks from the GitHub repository via JupyterLab.

The bad news:
- Stuffing an entire Jupyter notebook into an iframe with an arbitrary height is clunky, as expected. It might be possible to use some fringe JavaScript tricks to make the iframe height adjust to the content, but this wouldn't bode well for long-term maintenance IMO.
- There appears to be no way to hide the file navigation sidebar (through an HTTP GET parameter or otherwise) without the user doing this manually.
- The browser back button stops working as soon as you embed JupyterLab into an iframe, and I found no obvious way through Nuxt routing, Vue lifecycle hooks, etc. to restore its functionality. Disabling the browser's back button appears to be a deliberate decision by JupyterLab.

So, I think the bad outweighs the good here and it would be better to link to Jupyter notebooks directly (via JupyterLab) from the item teaser "card" without an intermediate ARDAC page.