### PR TITLE
Add optional item priority field to control page sorting

### DIFF
--- a/assets/items.js
+++ b/assets/items.js
@@ -34,8 +34,10 @@ export default [
       'Visualization',
       'Map',
     ],
+    priority: 2,
   },
   {
+    priority: 1,
     type: 'general',
     image: '/previews/ncr-preview.png',
     imageAlt: 'logo for northern climate reports website',
@@ -67,6 +69,7 @@ export default [
     tags: ['Code', 'Notebook'],
   },
   {
+    priority: 1,
     type: 'general',
     title: 'Arctic Engineering Design and Decision Support Tool (Arctic-EDS)',
     blurb: `Access data to support Arctic engineering: climate model outputs aggregated for easy access and integration into engineering workflows.  Download data subsets for communities and points across Alaska, and see data summaries and aggregation for near- to late-century model outputs.`,

--- a/components/ResultsCount.vue
+++ b/components/ResultsCount.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { useStore } from '~/stores/store'
 const store = useStore()
-const resultsCount = computed(() => store.filteredItems.length)
+const resultsCount = computed(() => store.sortedFilteredItems.length)
 const searchActive = computed(() => store.searchActive)
 const totalItemCount = computed(() => store.totalItemCount)
 </script>

--- a/pages/full.vue
+++ b/pages/full.vue
@@ -1,5 +1,4 @@
 <script lang="ts" setup>
-
 import type { ConcreteComponent } from 'vue'
 import { getCurrentInstance } from 'vue'
 import items from '~/assets/items'

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -8,7 +8,7 @@ import { useStore } from '~/stores/store'
 const { $Masonry } = useNuxtApp()
 const store = useStore()
 
-const items = computed<any[]>(() => store.filteredItems)
+const items = computed<any[]>(() => store.sortedFilteredItems)
 const searchActive = computed(() => store.searchActive)
 
 const populatePage = () => {
@@ -21,6 +21,7 @@ const populatePage = () => {
     new $Masonry('.grid', {
       itemSelector: gridItemSelector,
       columnWidth: columnWidth,
+      horizontalOrder: true,
     })
   }, 0)
 }

--- a/pages/tag/[tag].vue
+++ b/pages/tag/[tag].vue
@@ -1,11 +1,14 @@
 <script lang="ts" setup>
 import items from '~/assets/items'
+import { useStore } from '~/stores/store'
 const route = useRoute()
 const { $Masonry } = useNuxtApp()
+const store = useStore()
 
 let tag = route.params.tag as string
-let matchedItems = items.filter(item => item.tags?.includes(tag))
-let matchedItemsCount = matchedItems.length
+let filteredItems = items.filter(item => item.tags?.includes(tag))
+store.filteredItems = filteredItems
+let filteredItemsCount = store.sortedFilteredItems.length
 
 onMounted(() => {
   setTimeout(() => {
@@ -17,16 +20,15 @@ onMounted(() => {
     })
   }, 0)
 })
-
 </script>
 
 <template>
   <section class="section">
     <div class="container">
       <h2 class="title is-2">{{ tag }}</h2>
-      <h3 class="subtitle is-3">{{ matchedItemsCount }} matching items</h3>
+      <h3 class="subtitle is-3">{{ filteredItemsCount }} matching items</h3>
       <div class="grid">
-        <div v-for="item in matchedItems" class="grid-item">
+        <div v-for="item in store.sortedFilteredItems" class="grid-item">
           <Item
             :type="item.type"
             :image="item.image"

--- a/stores/store.ts
+++ b/stores/store.ts
@@ -6,9 +6,23 @@ export const useStore = defineStore('store', () => {
   const filteredItems = ref(items)
   const searchActive = ref(false)
 
+  // Sort items with a priority field above items without a priority field.
+  // For items with a priority field, lower numbers sort higher.
+  const sortedFilteredItems = computed(() => {
+    let itemsWithPriority = filteredItems.value.filter(
+      item => item.priority !== undefined
+    )
+    let itemsWithoutPriority = filteredItems.value.filter(
+      item => !item.priority
+    )
+    itemsWithPriority.sort((a, b) => a.priority! - b.priority!)
+    return itemsWithPriority.concat(itemsWithoutPriority)
+  })
+
   return {
     filteredItems,
     searchActive,
     totalItemCount,
+    sortedFilteredItems,
   }
 })


### PR DESCRIPTION
This PR adds an optional `priority` field for items. This field controls how items are ordered on the front/tag pages. Items without a `priority` field are sorted below all items that do have a `priority` field. Currently, lower priority numbers sort higher up on the page.

This works by first sorting the array of items as described above, and then taking advantage of Masonry's [horizontalOrder](https://masonry.desandro.com/options#horizontalorder) option to keep higher priority elements at the top while still fitting things together in an optimal way.

To test, try setting the priority of items in `items.js` in different ways and make sure the items are sorted on the page(s) the way you'd expect. Try this on both the front page and the item pages. Browser reload may be required after changing `items.js`.