### PR TITLE
Switch results to table format if there are five items or less

### DIFF
--- a/components/ResultsTable.vue
+++ b/components/ResultsTable.vue
@@ -1,0 +1,22 @@
+<script lang="ts" setup>
+const props = defineProps<{
+  items: Item[]
+}>()
+</script>
+
+<template>
+  <table class="table m-2 mt-5">
+    <thead>
+      <tr>
+        <th class="pr-3">Title</th>
+        <th class="pl-3">Description</th>
+      </tr>
+    </thead>
+    <tr v-for="item in items">
+      <td v-html="item.title" class="pr-3 py-2" />
+      <td v-html="item.blurb" class="pl-3 py-2" />
+    </tr>
+  </table>
+</template>
+
+<style lang="scss" scoped></style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -40,7 +40,7 @@ watch([items, searchActive], async () => {
       <Search class="mb-6" />
       <ResultsCount />
 
-      <div v-if="items.length > 0" class="mb-6 grid">
+      <div v-if="items.length > 5" class="mb-6 grid">
         <div v-for="item in items" class="grid-item">
           <Item
             :type="item.type"
@@ -53,6 +53,9 @@ watch([items, searchActive], async () => {
             :fullView="item.fullView"
           />
         </div>
+      </div>
+      <div v-else-if="items.length > 0" class="mb-6">
+        <ResultsTable :items="items" />
       </div>
     </div>
   </section>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -10,10 +10,13 @@ const store = useStore()
 
 const items = computed<any[]>(() => store.filteredItems)
 const searchActive = computed(() => store.searchActive)
+const masonryThreshold = 5
 
 const populatePage = () => {
   setTimeout(() => {
-    if (items.value.length === 0) {
+    // Use table display instead of Masonry if the number of filtered items is
+    // less than or equal to the masonryThreshold.
+    if (items.value.length <= masonryThreshold) {
       return
     }
     let gridItemSelector = '.grid-item'
@@ -40,7 +43,7 @@ watch([items, searchActive], async () => {
       <Search class="mb-6" />
       <ResultsCount />
 
-      <div v-if="items.length > 5" class="mb-6 grid">
+      <div v-if="items.length > masonryThreshold" class="mb-6 grid">
         <div v-for="item in items" class="grid-item">
           <Item
             :type="item.type"


### PR DESCRIPTION
This PR changes the front page to display items in table format if there are five or less search results. I've omitted thumbnail images from the table display because they would either take up too much room in the table (IMO) or be too small to see the thumbnail details.

To test, load the app and search for something until you have five or less results.