### PR TITLE
Add example Plotly chart that reacts to lat/lon input

### DIFF
--- a/assets/items.js
+++ b/assets/items.js
@@ -115,4 +115,11 @@ export default [
     blurb: `Download projections of permafrost top and base depths, talik thickness, and mean annual ground temperature at seven different depths for years 2021–2120, provided by the Geophysical Institute Permafrost Lab (GIPL 2.0) model.`,
     tags: ['API', 'Permafrost'],
   },
+  {
+    type: 'general',
+    slug: 'precipitation-frequency',
+    title: 'Precipitation frequency',
+    blurb: `View an interactive chart of precipitation frequency using data from the SNAP Data API.`,
+    tags: ['API'],
+  },
 ]

--- a/components/LatLngSelector.vue
+++ b/components/LatLngSelector.vue
@@ -2,6 +2,8 @@
 // bbox order is left, bottom, right, top
 const props = defineProps<{
   bbox?: number[]
+  label?: string
+  errorMsg?: string
 }>()
 
 const { $parseDMS } = useNuxtApp()
@@ -9,6 +11,11 @@ const store = useStore()
 const latLngInput = defineModel()
 const latLng = ref()
 const fieldMessage = ref('')
+const inputLabel = ref('Get data for lat/lon point:')
+
+if (props.label) {
+  inputLabel.value = props.label
+}
 
 let bbox: number[]
 if (props.bbox) {
@@ -72,12 +79,21 @@ const validate = () => {
 onUnmounted(() => {
   store.latLng = {} as LatLng
 })
+
+watch(
+  () => props.errorMsg,
+  async () => {
+    if (props.errorMsg) {
+      invalidLatLng(props.errorMsg)
+    }
+  }
+)
 </script>
 
 <template>
   <div class="field my-6">
     <div class="control">
-      <label class="label">Get data for lat/lon point:</label>
+      <label class="label" v-html="inputLabel" />
       <input
         class="input is-primary mr-3"
         type="text"

--- a/components/global/PrecipitationFrequency.vue
+++ b/components/global/PrecipitationFrequency.vue
@@ -116,7 +116,7 @@ watch(apiData, async () => {
 watch(latLng, async () => {
   errorMsg.value = ''
   $Plotly.purge('chart')
-  dataStore.fetchData()
+  dataStore.fetchData('precipitationFrequency')
 })
 watch(dataError, async () => {
   if (dataError.value === true) {

--- a/components/global/PrecipitationFrequency.vue
+++ b/components/global/PrecipitationFrequency.vue
@@ -1,0 +1,142 @@
+<script lang="ts" setup>
+import type { Data } from 'plotly.js-dist-min'
+
+const { $Plotly } = useNuxtApp()
+const store = useStore()
+const dataStore = useDataStore()
+
+const apiData = computed<any[]>(() => dataStore.apiData)
+const dataError = computed<boolean>(() => dataStore.dataError)
+const latLng = computed<LatLng>(() => store.latLng)
+const errorMsg = ref('')
+
+const buildChart = () => {
+  if (apiData.value) {
+    let models = ['GFDL-CM3', 'NCAR-CCSM4']
+    let eras = ['2020-2049', '2050-2079', '2080-2099']
+
+    let traces: Data[] = []
+    let offsets: Record<string, number> = {
+      'GFDL-CM3': -0.05,
+      'NCAR-CCSM4': 0.05,
+    }
+    let symbols: Record<string, string> = {
+      'GFDL-CM3': 'circle',
+      'NCAR-CCSM4': 'square',
+    }
+    let ticks = [0, 1, 2, 3]
+    let chartData = dataStore.apiData['100']['24h']
+    models.forEach(model => {
+      let pf: number[] = []
+      let pf_upper: number[] = []
+      let pf_lower: number[] = []
+
+      // Offset the chart markers/bars slightly so they don't overlap.
+      // Omit the first tick mark because it's just the placeholder for the
+      // 0 x-axis position, where the y-axis line is drawn.
+      let offsetTicks = ticks.slice(1).map(tick => tick + offsets[model])
+      eras.forEach(era => {
+        pf.push(chartData[model][era]['pf'])
+        pf_upper.push(chartData[model][era]['pf_upper'])
+        pf_lower.push(chartData[model][era]['pf_lower'])
+      })
+
+      traces.push({
+        x: offsetTicks,
+        y: pf,
+        error_y: {
+          type: 'data',
+          symmetric: false,
+          array: pf_upper,
+          arrayminus: pf_lower,
+        },
+        mode: 'markers',
+        type: 'scatter',
+        name: model,
+        marker: {
+          symbol: Array(ticks.length).fill(symbols[model]),
+          size: 8,
+        },
+      })
+    })
+
+    $Plotly.newPlot(
+      'chart',
+      traces,
+      {
+        title: {
+          text:
+            'Precipitation frequency for ' +
+            store.latLng.lat +
+            ',' +
+            store.latLng.lng +
+            '<br />' +
+            'Duration: 24 hours, Annual exceedance probability: 1%',
+          font: {
+            size: 24,
+          },
+        },
+        xaxis: {
+          tickvals: ticks,
+          ticktext: ['', ...eras],
+          dtick: 1,
+        },
+        yaxis: {
+          title: {
+            text: 'Precipitation (㎜)',
+            font: {
+              size: 18,
+            },
+          },
+        },
+      },
+      {
+        responsive: true, // changes the height / width dynamically for charts
+        displayModeBar: true, // always show the camera icon
+        displaylogo: false,
+        modeBarButtonsToRemove: [
+          'zoom2d',
+          'pan2d',
+          'select2d',
+          'lasso2d',
+          'zoomIn2d',
+          'zoomOut2d',
+          'autoScale2d',
+          'resetScale2d',
+        ],
+      }
+    )
+  }
+}
+
+watch(apiData, async () => {
+  buildChart()
+})
+
+watch(latLng, async () => {
+  errorMsg.value = ''
+  $Plotly.purge('chart')
+  dataStore.fetchData()
+})
+watch(dataError, async () => {
+  if (dataError.value === true) {
+    errorMsg.value =
+      'There was an error fetching data for this location. Please try another location.'
+  }
+})
+</script>
+
+<template>
+  <section class="section">
+    <div class="content is-size-5">
+      <h3 class="title is-3">Precipitation Frequency</h3>
+      <LatLngSelector
+        label="Get chart for lat/lon point:"
+        :errorMsg="errorMsg"
+      />
+      <div id="chart"></div>
+    </div>
+  </section>
+</template>
+
+<style scoped></style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,18 @@
       "dependencies": {
         "@pinia/nuxt": "^0.5.1",
         "@tarekraafat/autocomplete.js": "^10.2.7",
-        "@types/proj4leaflet": "^1.0.10",
+        "@types/plotly.js-dist-min": "^2.3.4",
         "bulma": "^0.9.4",
         "leaflet": "^1.9.4",
         "masonry-layout": "^4.2.2",
+        "parse-dms": "^0.0.5",
         "pinia": "^2.1.7",
-        "proj4leaflet": "^1.0.2",
-        "parse-dms": "^0.0.5"
+        "plotly.js-dist-min": "^2.29.0",
+        "proj4leaflet": "^1.0.2"
       },
       "devDependencies": {
         "@types/leaflet": "^1.9.8",
+        "@types/proj4leaflet": "^1.0.10",
         "nuxt": "^3.9.0",
         "prettier": "^3.2.2",
         "sass": "^1.69.7",
@@ -2485,7 +2487,8 @@
     "node_modules/@types/geojson": {
       "version": "7946.0.14",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
-      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==",
+      "dev": true
     },
     "node_modules/@types/http-proxy": {
       "version": "1.17.14",
@@ -2500,6 +2503,7 @@
       "version": "1.9.8",
       "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.8.tgz",
       "integrity": "sha512-EXdsL4EhoUtGm2GC2ZYtXn+Fzc6pluVgagvo2VC1RHWToLGlTRwVYoDpqS/7QXa01rmDyBjJk3Catpf60VMkwg==",
+      "dev": true,
       "dependencies": {
         "@types/geojson": "*"
       }
@@ -2513,15 +2517,30 @@
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/@types/plotly.js": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@types/plotly.js/-/plotly.js-2.29.0.tgz",
+      "integrity": "sha512-iFHic6T4o6/olhqGvPhh/D0sdEoYhvU639xlMd5VCW7b+8VBS9RmkcLvoJFHXuuJUBVTlAxZaB9FQbkH2oi+lQ=="
+    },
+    "node_modules/@types/plotly.js-dist-min": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/plotly.js-dist-min/-/plotly.js-dist-min-2.3.4.tgz",
+      "integrity": "sha512-ISwLFV6Zs/v3DkaRFLyk2rvYAfVdnYP2VVVy7h+fBDWw52sn7sMUzytkWiN4M75uxr1uz1uiBioePTDpAfoFIg==",
+      "dependencies": {
+        "@types/plotly.js": "*"
+      }
+    },
     "node_modules/@types/proj4": {
       "version": "2.5.5",
       "resolved": "https://registry.npmjs.org/@types/proj4/-/proj4-2.5.5.tgz",
-      "integrity": "sha512-y4tHUVVoMEOm2nxRLQ2/ET8upj/pBmoutGxFw2LZJTQWPgWXI+cbxVEUFFmIzr/bpFR83hGDOTSXX6HBeObvZA=="
+      "integrity": "sha512-y4tHUVVoMEOm2nxRLQ2/ET8upj/pBmoutGxFw2LZJTQWPgWXI+cbxVEUFFmIzr/bpFR83hGDOTSXX6HBeObvZA==",
+      "dev": true
     },
     "node_modules/@types/proj4leaflet": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/@types/proj4leaflet/-/proj4leaflet-1.0.10.tgz",
       "integrity": "sha512-Yie5J8sHUgTQ1FTRP9cCDXpWvHXjUiSjwlnJb1F06Czwo6cVOt8Bxy6txMSIVgznbnRWlbYmxNjWDhYtNxAflw==",
+      "dev": true,
       "dependencies": {
         "@types/geojson": "*",
         "@types/leaflet": "*",
@@ -7141,6 +7160,11 @@
         "mlly": "^1.2.0",
         "pathe": "^1.1.0"
       }
+    },
+    "node_modules/plotly.js-dist-min": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/plotly.js-dist-min/-/plotly.js-dist-min-2.29.0.tgz",
+      "integrity": "sha512-B+eZiFXuS5UGRdlVE4KrjZl2Q+ajg30pjMStP1jUiVFBB8kd/6yNby9DYxpiadOoqB9fE270ZPmZnmVkCQtT6w=="
     },
     "node_modules/postcss": {
       "version": "8.4.33",

--- a/package.json
+++ b/package.json
@@ -23,11 +23,13 @@
   "dependencies": {
     "@pinia/nuxt": "^0.5.1",
     "@tarekraafat/autocomplete.js": "^10.2.7",
+    "@types/plotly.js-dist-min": "^2.3.4",
     "bulma": "^0.9.4",
     "leaflet": "^1.9.4",
     "masonry-layout": "^4.2.2",
+    "parse-dms": "^0.0.5",
     "pinia": "^2.1.7",
-    "proj4leaflet": "^1.0.2",
-    "parse-dms": "^0.0.5"
+    "plotly.js-dist-min": "^2.29.0",
+    "proj4leaflet": "^1.0.2"
   }
 }

--- a/plugins/plotly.client.ts
+++ b/plugins/plotly.client.ts
@@ -1,0 +1,9 @@
+import Plotly from 'plotly.js-dist-min'
+
+export default defineNuxtPlugin(nuxtApp => {
+  return {
+    provide: {
+      Plotly,
+    },
+  }
+})

--- a/stores/data.ts
+++ b/stores/data.ts
@@ -2,18 +2,22 @@ import { defineStore } from 'pinia'
 const runtimeConfig = useRuntimeConfig()
 const store = useStore()
 
+const endpoints: Record<string, string> = {
+  precipitationFrequency: '/precipitation/frequency/point/',
+}
+
 export const useDataStore = defineStore('data', () => {
   // Use "any" type since apiData will be used to store many different types of
   // data we will get from the API for different ARDAC items.
   const apiData: any = ref(null)
   const dataError: Ref<boolean> = ref(false)
 
-  const fetchData = async () => {
+  const fetchData = async (dataset: string) => {
     apiData.value = null
     dataError.value = false
     let url =
       runtimeConfig.public.apiUrl +
-      '/precipitation/frequency/point/' +
+      endpoints[dataset] +
       store.latLng.lat +
       '/' +
       store.latLng.lng

--- a/stores/data.ts
+++ b/stores/data.ts
@@ -1,0 +1,38 @@
+import { defineStore } from 'pinia'
+const runtimeConfig = useRuntimeConfig()
+const store = useStore()
+
+export const useDataStore = defineStore('data', () => {
+  // Use "any" type since apiData will be used to store many different types of
+  // data we will get from the API for different ARDAC items.
+  const apiData: any = ref(null)
+  const dataError: Ref<boolean> = ref(false)
+
+  const fetchData = async () => {
+    apiData.value = null
+    dataError.value = false
+    let url =
+      runtimeConfig.public.apiUrl +
+      '/precipitation/frequency/point/' +
+      store.latLng.lat +
+      '/' +
+      store.latLng.lng
+    try {
+      const response = await fetch(url)
+      const data = await response.json()
+      if (response.status === 200) {
+        apiData.value = data
+      } else {
+        dataError.value = true
+      }
+    } catch (error) {
+      dataError.value = true
+    }
+  }
+
+  return {
+    fetchData,
+    apiData,
+    dataError,
+  }
+})


### PR DESCRIPTION
This PR does a few things:

- Adds Plotly as a Nuxt plugin
- Adds a new `data` store that is meant to be a one-stop shop for Data API interactions
- Adds a new "Precipitation frequency" ARDAC item that uses the existing `LatLngSelector` component to generate Plotly charts based on lat/lon inputs

To test, do an `npm install`, then load the full view for the "Precipitation frequency" item and interact with the lat/lon input to generate charts. The `LatLngSelector` component already checks for malformed and out-of-BBOX lat/lons, but it's also now rigged up to react to nodata responses/values received from the Data API, such as precipitation frequency requests that are over the ocean (e.g., 63, -167).