### PR TITLE
Implement Tag type with possible values

### DIFF
--- a/pages/tag/[tag].vue
+++ b/pages/tag/[tag].vue
@@ -7,8 +7,10 @@ const route = useRoute()
 const store = useStore()
 
 // Get stuff filtered/prioritized
-let tag = route.params.tag as string
-let filteredItems: Item[] = items.filter(item => item.tags?.includes(tag))
+let tag = route.params.tag as Tag
+let filteredItems: Item[] = items.filter((item: Item) =>
+  item.tags?.includes(tag)
+)
 store.filteredItems = filteredItems
 let filteredItemsCount = store.sortedFilteredItems.length
 

--- a/scripts/csv2json.cjs
+++ b/scripts/csv2json.cjs
@@ -1,18 +1,22 @@
-// This is just some sample code for working with 
+// This is just some sample code for working with
 // a (temporary!) spreadsheet version of some items.
 // Below it sketches an example that outputs JSON,
-// and also a version that just outputs type defs for Slugs.
+// and also a version that outputs type defs for
+// Slugs and Tags.
 const csvFile = './input.csv'
 const csv = require('csvtojson')
 var out = []
+let tags = new Set()
+
+console.log('type Slug =')
 csv({
-	ignoreColumns: /What/, // ignore the "What should it offer?" column
+  ignoreColumns: /What/, // ignore the "What should it offer?" column
 })
-	.fromFile(csvFile)
-	.subscribe(json => {
-		return new Promise((resolve, reject) => {
-			// Generate most of the needed JSON in bulk
-			/*
+  .fromFile(csvFile)
+  .subscribe(json => {
+    return new Promise((resolve, reject) => {
+      // Generate most of the needed JSON in bulk
+      /*
 			let tags = json.tags.split(',')
 			tags.forEach((tag, i) => {
 				tags[i] = tag.trim()
@@ -25,9 +29,19 @@ csv({
 			},',')
 			*/
 
-			/* Regenerate valid slugs */
-			console.log('| "' + json.slug + '"')
+      /* Regenerate valid slugs */
+      console.log("  | '" + json.slug + "'")
 
-			resolve()
-		})
-	})
+      /* Add tags to set to be output later */
+      json.tags.split(', ').forEach(tag => {
+        tags.add(tag)
+      })
+      resolve()
+    })
+  })
+  .then(() => {
+    console.log('\ntype Tag =')
+    tags.forEach(tag => {
+      console.log("  | '" + tag + "'")
+    })
+  })

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -2,7 +2,7 @@ interface Item {
   slug: Slug
   title: string
   blurb: string
-  tags?: string[]
+  tags?: Tag[]
   image?: string
   imageAlt?: string
   priority?: number

--- a/types/tags.d.ts
+++ b/types/tags.d.ts
@@ -1,0 +1,8 @@
+type Tag =
+  | 'Climate'
+  | 'Precipitation'
+  | 'Hydrology'
+  | 'Permafrost'
+  | 'Cryosphere'
+  | 'Programming'
+  | 'Temperature'


### PR DESCRIPTION
This PR basically does the same thing for item tags that we did for slugs. It defines a new `Tag` type with a list of possible values generated using `csv2json.cjs` (with the necessary modifications).

I've also confirmed that, with this change, VS Code now autocompletes tags when editing `items.ts` and underlines invalid tags.

To test, make sure the app runs like before. Then try adding an invalid tag to an item in `items.ts` and make sure the TypeScript police catch you. 🚨