### PR TITLE
Redirect S3 hashbang path redirects to their corresponding Nuxt paths

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 // Redirect S3 hashbang URLs to Nuxt URLs.
 const route = useRoute()
-onMounted(() => {
+onBeforeMount(() => {
   if (route.hash.substring(0, 3) == '#!/') {
     navigateTo(route.hash.substring(2))
   }

--- a/app.vue
+++ b/app.vue
@@ -1,0 +1,17 @@
+<script lang="ts" setup>
+// Redirect S3 hashbang URLs to Nuxt URLs.
+const route = useRoute()
+onMounted(() => {
+  if (route.hash.substring(0, 3) == '#!/') {
+    navigateTo(route.hash.substring(2))
+  }
+})
+</script>
+
+<template>
+  <div>
+    <NuxtLayout>
+      <NuxtPage />
+    </NuxtLayout>
+  </div>
+</template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,6 +2,14 @@
 definePageMeta({
   layout: 'home',
 })
+
+// Redirect S3 hashbang URLs to Nuxt URLs.
+const route = useRoute()
+onMounted(() => {
+  if (route.hash.substring(0, 3) == '#!/') {
+    navigateTo(route.hash.substring(2), { external: true })
+  }
+})
 </script>
 
 <template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,14 +2,6 @@
 definePageMeta({
   layout: 'home',
 })
-
-// Redirect S3 hashbang URLs to Nuxt URLs.
-const route = useRoute()
-onMounted(() => {
-  if (route.hash.substring(0, 3) == '#!/') {
-    navigateTo(route.hash.substring(2), { external: true })
-  }
-})
 </script>
 
 <template>


### PR DESCRIPTION
Closes #51.

This PR adds S3 permalink support in a way that is similar to how our other webapps (Northern Climate Reports, Arctic-EDS) do it, but adapted to work with Nuxt 3.

While permalinks do already work when running the app locally, the issue with S3 is that since the webapp is served as a static website, all traffic needs to land on `index.html` to access the app before being routed to a specific path within the app. To do this, we use S3 settings to route all 404s to `index.html` and then reroute them back to the requested webapp path.

I initially implemented this rerouting trick in `pages/index.vue`, but when doing so, it failed to recognize when I requested a non-existing file path and silently routed to the front page of the app. To fix this, I had to create an `app.vue` and put the rerouting code there. It turns out `app.vue` is considered a [fundamental part of a Nuxt 3 app](https://nuxt.com/docs/guide/directory-structure/app), so I'm not sure why we didn't already have one or why things worked without it, but everything appears to be working the same as before with it.

To test, I've gone ahead and deployed this branch to our dev S3 bucket. Confirm that this URL routes you to the correct page (you may need to clear your browser cache or use a different browser if you already clicked this link previously):
http://arcticdatascience.org/item/indicator-rx5day