### PR TITLE
Implement map + chart for the 4 currently available CMIP6 indicator ARDAC items

### DIFF
--- a/assets/items.ts
+++ b/assets/items.ts
@@ -1,15 +1,5 @@
 export default [
   {
-    slug: 'indicator-ftc',
-    title: 'Freeze/Thaw Cycle',
-    blurb:
-      'Annual count of days with low temperature below freezing and high temps above freezing',
-    tags: ['Climate'],
-    image: 'freeze-thaw_ilona-frey-unsplash.jpg',
-    imageAlt:
-      'Photo of icicles demonstrating a freeze/thaw cycle.  Photo by Ilona Frey on Unsplash.',
-  },
-  {
     slug: 'indicator-su',
     title: 'Summer Days',
     blurb: 'Annual count when daily max temperature (threshold) >25°C',
@@ -390,5 +380,33 @@ export default [
     title: 'Snow, CMIP6',
     blurb: 'Snow amount, snowfall flux and surface snow thickness',
     tags: ['Cryosphere', 'Snow', 'CMIP6'],
+  },
+  {
+    slug: 'indicator-ftc-cmip6',
+    title: 'Freeze/Thaw Cycle, CMIP6',
+    blurb:
+      'Annual count of days with low temperature below freezing and high temps above freezing',
+    tags: ['Climate', 'CMIP6'],
+    image: 'freeze-thaw_ilona-frey-unsplash.jpg',
+    imageAlt:
+      'Photo of icicles demonstrating a freeze/thaw cycle.  Photo by Ilona Frey on Unsplash.',
+  },
+  {
+    slug: 'indicator-su-cmip6',
+    title: 'Summer Days, CMIP6',
+    blurb: 'Annual count when daily max temperature (threshold) >25°C',
+    tags: ['Climate', 'CMIP6'],
+  },
+  {
+    slug: 'indicator-dw-cmip6',
+    title: 'Deep Winter Days, CMIP6',
+    blurb: 'Annual count when daily min temperature (threshold) <-30°C',
+    tags: ['Climate', 'CMIP6'],
+  },
+  {
+    slug: 'indicator-rx1day-cmip6',
+    title: 'Maximum 1-day Precipitation, CMIP6',
+    blurb: 'Maximum precipitation in a single calendar year.',
+    tags: ['Precipitation', 'Climate', 'CMIP6'],
   },
 ] satisfies Item[]

--- a/components/FrontPage/Main.vue
+++ b/components/FrontPage/Main.vue
@@ -14,7 +14,7 @@
 
         <ul>
           <li>
-            <ItemBrief slug="indicator-ftc" showTag />
+            <ItemBrief slug="indicator-ftc-cmip6" showTag />
           </li>
           <li>
             <ItemBrief slug="indicator-rx1day" showTag />

--- a/components/FrontPage/Section/Climate.vue
+++ b/components/FrontPage/Section/Climate.vue
@@ -11,7 +11,7 @@
 
       <div class="tile is-parent">
         <div class="tile is-child">
-          <ItemTextPicture slug="indicator-ftc" />
+          <ItemTextPicture slug="indicator-ftc-cmip6" />
         </div>
       </div>
 

--- a/components/IndicatorsCmip6Chart.vue
+++ b/components/IndicatorsCmip6Chart.vue
@@ -28,18 +28,18 @@ const getPlotValues = (params: any) => {
   let years = $_.range(params.minYear, params.maxYear + 1)
 
   // Pad projected decades with nulls to align properly on chart.
-  let xTickPaddingLength: number = (params.minYear - 1850) / 10
+  let xTickPaddingLength: number = (params.minYear - 1950) / 10
   let xTickPadding = $_.fill(Array(xTickPaddingLength), null)
 
   let values: number[] = []
 
   if (params.historical) {
     years.forEach((year: number) => {
-      values.push(chartData['historical'][params.model][year]['ftc'])
+      values.push(chartData['historical'][params.model][year][props.dataKey])
     })
   } else {
     years.forEach((year: number) => {
-      values.push(chartData[params.scenario][params.model][year]['ftc'])
+      values.push(chartData[params.scenario][params.model][year][props.dataKey])
     })
   }
 
@@ -101,7 +101,7 @@ const buildChart = () => {
     let allDecades: string[] = []
     chartData = dataStore.apiData
 
-    for (let i = 1850; i <= 2090; i += 10) {
+    for (let i = 1950; i <= 2090; i += 10) {
       allDecades.push(i + '-' + (i + 9))
     }
 
@@ -109,7 +109,7 @@ const buildChart = () => {
       {
         model: chartInputs.value?.model,
         scenario: chartInputs.value?.scenario,
-        minYear: 1850,
+        minYear: 1950,
         maxYear: 2009,
         historical: true,
       },

--- a/components/IndicatorsCmip6Chart.vue
+++ b/components/IndicatorsCmip6Chart.vue
@@ -63,7 +63,7 @@ const getPlotValues = (params: any) => {
   let minOffsets: number[] = []
 
   decades.forEach(decade => {
-    let mean = Math.round($_.mean(decadeBuckets[decade]))
+    let mean = $_.mean(decadeBuckets[decade])
     let min = $_.min(decadeBuckets[decade])
     let max = $_.max(decadeBuckets[decade])
 
@@ -101,7 +101,7 @@ const buildChart = () => {
     let allDecades: string[] = []
     chartData = dataStore.apiData
 
-    for (let i = 1950; i <= 2090; i += 10) {
+    for (let i = 1950; i <= 2100; i += 10) {
       allDecades.push(i + '-' + (i + 9))
     }
 

--- a/components/IndicatorsCmip6ChartControls.vue
+++ b/components/IndicatorsCmip6ChartControls.vue
@@ -3,12 +3,14 @@ const props = defineProps<{
   defaultMonth?: string
 }>()
 
+const dataStore = useDataStore()
 const placesStore = usePlacesStore()
 const chartStore = useChartStore()
 
 const modelInput = defineModel('model', { default: 'GFDL-ESM4' })
 const scenarioInput = defineModel('scenario', { default: 'ssp585' })
 
+const apiData = computed<any[]>(() => dataStore.apiData)
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const chartLabels = computed<IndicatorsCmip6ChartLabels>(
@@ -45,7 +47,7 @@ watch([latLng, modelInput, scenarioInput], async () => {
 </script>
 
 <template>
-  <div v-if="latLng && chartLabels">
+  <div v-if="latLng && chartLabels && apiData">
     <div class="columns is-multiline">
       <div class="column is-6">
         <div class="parameter">

--- a/components/IndicatorsCmip6ChartControls.vue
+++ b/components/IndicatorsCmip6ChartControls.vue
@@ -1,0 +1,94 @@
+<script lang="ts" setup>
+const props = defineProps<{
+  defaultMonth?: string
+}>()
+
+const placesStore = usePlacesStore()
+const chartStore = useChartStore()
+
+const modelInput = defineModel('model', { default: 'GFDL-ESM4' })
+const scenarioInput = defineModel('scenario', { default: 'ssp585' })
+
+const latLng = computed<LatLngValue>(() => placesStore.latLng)
+
+const chartLabels = computed<IndicatorsCmip6ChartLabels>(
+  () => chartStore.labels as IndicatorsCmip6ChartLabels
+)
+
+chartStore.labels = {
+  models: {
+    'CNRM-CM6-1-HR': 'CNRM-CM6-1-HR',
+    'EC-Earth3-Veg': 'EC-Earth3-Veg',
+    'GFDL-ESM4': 'GFDL-ESM4',
+    'HadGEM-GC31-LL': 'HadGEM-GC31-LL',
+    'HadGEM-GC31-MM': 'HadGEM-GC31-MM',
+    'KACE-1-0-G': 'KACE-1-0-G',
+    MIROC6: 'MIROC6',
+    'MPI-ESM1-2-LR': 'MPI-ESM1-2-LR',
+    'NorESM2-MM': 'NorESM2-MM',
+    TaiESM1: 'TaiESM1',
+  },
+  scenarios: {
+    ssp126: 'SSP1-2.6',
+    ssp245: 'SSP2-4.5',
+    ssp370: 'SSP3-7.0',
+    ssp585: 'SSP5-8.5',
+  },
+}
+
+watch([latLng, modelInput, scenarioInput], async () => {
+  chartStore.inputs = {
+    model: modelInput.value,
+    scenario: scenarioInput.value,
+  }
+})
+</script>
+
+<template>
+  <div v-if="latLng && chartLabels">
+    <div class="columns is-multiline">
+      <div class="column is-6">
+        <div class="parameter">
+          <label for="model" class="label">Model:</label>
+          <div class="select">
+            <select v-model="modelInput">
+              <option
+                v-for="(label, value) in chartLabels.models"
+                :key="value"
+                :value="value"
+              >
+                {{ label }}
+              </option>
+            </select>
+          </div>
+        </div>
+      </div>
+      <div class="column is-6">
+        <div class="parameter">
+          <label for="scenario" class="label">Scenario:</label>
+          <div class="select">
+            <select v-model="scenarioInput">
+              <option
+                v-for="(label, value) in chartLabels.scenarios"
+                :key="value"
+                :value="value"
+              >
+                {{ label }}
+              </option>
+            </select>
+          </div>
+        </div>
+      </div>
+    </div>
+    <HydrologyChart />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.parameter {
+  display: inline-block;
+  select {
+    background-color: $white-lighter;
+  }
+}
+</style>

--- a/components/global/IndicatorDwCmip6.vue
+++ b/components/global/IndicatorDwCmip6.vue
@@ -1,16 +1,83 @@
 <script lang="ts" setup>
 const placesStore = usePlacesStore()
+const mapStore = useMapStore()
 const dataStore = useDataStore()
 const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData)
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+
+const layers: MapLayer[] = [
+  {
+    id: 'indicator_dw_historical_era',
+    title: '1980–2009, GFDL-ESM4',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_indicators',
+    style: 'ardac_indicator_dw_historical_era',
+    legend: 'deep_winter_days',
+    rasdamanConfiguration: { dim_model: 4, dim_scenario: 0 },
+  },
+  {
+    id: 'indicator_dw_midcentury_era',
+    title: '2040–2069, GFDL-ESM4, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_indicators',
+    style: 'ardac_indicator_dw_midcentury_era',
+    legend: 'deep_winter_days',
+    rasdamanConfiguration: { dim_model: 4, dim_scenario: 4 },
+  },
+  {
+    id: 'indicator_dw_latecentury_era',
+    title: '2070–2099, GFDL-ESM4, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_indicators',
+    style: 'ardac_indicator_dw_latecentury_era',
+    legend: 'deep_winter_days',
+    rasdamanConfiguration: { dim_model: 4, dim_scenario: 4 },
+  },
+]
+
+const legend: Record<string, LegendItem[]> = {
+  deep_winter_days: [
+    { color: '#c6dbef', label: '&ge;1 day, &lt;10 days' },
+    { color: '#9ecae1', label: '&ge;10 days, &lt;20 days' },
+    { color: '#6baed6', label: '&ge;20 days, &lt;40 days' },
+    { color: '#3182bd', label: '&ge;40 days, &lt;80 days' },
+    { color: '#08519c', label: '&ge;80 days' },
+  ],
+}
+
+const mapId = 'deep_winter_days'
+mapStore.setLegendItems(mapId, legend)
 </script>
 
 <template>
   <section class="section">
     <div class="content is-size-5">
       <h3 class="title is-3">Deep Winter Days, CMIP6</h3>
+      <p class="mb-6">
+        Deep winter days are the number of days per year that are below
+        -22&deg;F. The map below shows the 30-year mean of CMIP6 deep winter
+        days for three eras. The historical era (1980&ndash;2009) uses
+        historical modeled data provided by the GFDL-ESM4 model. The mid-century
+        (2040&ndash;2069) and late-century (2070&ndash;2099) eras use modeled
+        projections from the GFDL-ESM4 model under the SSP5-8.5 emissions
+        scenario.
+      </p>
+
+      <MapBlock :mapId="mapId" class="mb-6">
+        <template v-slot:layers>
+          <MapLayer :mapId="mapId" :layer="layers[0]" default>
+            <template v-slot:title>{{ layers[0].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[1]">
+            <template v-slot:title>{{ layers[1].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[2]">
+            <template v-slot:title>{{ layers[2].title }}</template>
+          </MapLayer>
+        </template>
+      </MapBlock>
 
       <p>
         Enter lat/lon coordinates below to see a chart of deep winter days for a

--- a/components/global/IndicatorDwCmip6.vue
+++ b/components/global/IndicatorDwCmip6.vue
@@ -1,0 +1,68 @@
+<script lang="ts" setup>
+const placesStore = usePlacesStore()
+const dataStore = useDataStore()
+const runtimeConfig = useRuntimeConfig()
+
+const apiData = computed<Record<string, any>>(() => dataStore.apiData)
+const latLng = computed<LatLngValue>(() => placesStore.latLng)
+</script>
+
+<template>
+  <section class="section">
+    <div class="content is-size-5">
+      <h3 class="title is-3">Deep Winter Days, CMIP6</h3>
+
+      <p>
+        Enter lat/lon coordinates below to see a chart of deep winter days for a
+        point location. This chart displays annual min/mean/max values for
+        modeled historical and projected decades for ten models and four
+        scenarios. After entering lat/lon coordinates, links will be provided
+        where you can download the data that is used to populate the chart.
+      </p>
+
+      <Gimme />
+      <IndicatorsCmip6ChartControls />
+      <IndicatorsCmip6Chart label="Deep winter days" dataKey="dw" />
+
+      <div v-if="latLng && apiData" class="my-6">
+        <h4 class="title is-4">
+          Download deep winter days data for {{ latLng.lat }},
+          {{ latLng.lng }}
+        </h4>
+        <p>
+          The following download links bundle deep winter days data with other
+          climate indicators. Deep winter days use the "dw" identifier.
+        </p>
+        <ul>
+          <li>
+            <a
+              :href="
+                runtimeConfig.public.apiUrl +
+                '/indicators/cmip6/point/' +
+                latLng.lat +
+                '/' +
+                latLng.lng +
+                '?format=csv'
+              "
+              >Download as CSV</a
+            >
+          </li>
+          <li>
+            <a
+              :href="
+                runtimeConfig.public.apiUrl +
+                '/indicators/cmip6/point/' +
+                latLng.lat +
+                '/' +
+                latLng.lng
+              "
+              >Download as JSON</a
+            >
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped></style>

--- a/components/global/IndicatorFtcCmip6.vue
+++ b/components/global/IndicatorFtcCmip6.vue
@@ -27,7 +27,7 @@ const layers: MapLayer[] = [
     rasdamanConfiguration: { dim_model: 4, dim_scenario: 4 },
   },
   {
-    id: 'indicator_rx5day_latecentury_era',
+    id: 'indicator_ftc_latecentury_era',
     title: '2070–2099, GFDL-ESM4, SSP5-8.5',
     source: 'rasdaman',
     wmsLayerName: 'cmip6_indicators',

--- a/components/global/IndicatorFtcCmip6.vue
+++ b/components/global/IndicatorFtcCmip6.vue
@@ -1,0 +1,72 @@
+<script lang="ts" setup>
+const placesStore = usePlacesStore()
+const dataStore = useDataStore()
+const runtimeConfig = useRuntimeConfig()
+
+const apiData = computed<Record<string, any>>(() => dataStore.apiData)
+const latLng = computed<LatLngValue>(() => placesStore.latLng)
+</script>
+
+<template>
+  <section class="section">
+    <div class="content is-size-5">
+      <h3 class="title is-3">Freeze/Thaw Cycle</h3>
+
+      <p>
+        Enter lat/lon coordinates below to see a chart of freeze/thaw cycle days
+        for a point location. This chart displays annual min/mean/max values for
+        modeled historical and projected decades for ten models and four
+        scenarios. After entering lat/lon coordinates, links will be provided
+        where you can download the data that is used to populate the chart.
+      </p>
+
+      <Gimme />
+      <IndicatorsCmip6ChartControls />
+      <IndicatorsCmip6Chart
+        label="Freeze/thaw cycle"
+        units="days"
+        dataKey="ftc"
+      />
+
+      <div v-if="latLng && apiData" class="my-6">
+        <h4 class="title is-4">
+          Download freeze/thaw cycle data for {{ latLng.lat }},
+          {{ latLng.lng }}
+        </h4>
+        <p>
+          The following download links bundle freeze/thaw cycle data with other
+          climate indicators. Freeze/thaw cycle uses the "ftc" identifier.
+        </p>
+        <ul>
+          <li>
+            <a
+              :href="
+                runtimeConfig.public.apiUrl +
+                '/indicators/cmip6/point/' +
+                latLng.lat +
+                '/' +
+                latLng.lng +
+                '?format=csv'
+              "
+              >Download as CSV</a
+            >
+          </li>
+          <li>
+            <a
+              :href="
+                runtimeConfig.public.apiUrl +
+                '/indicators/cmip6/point/' +
+                latLng.lat +
+                '/' +
+                latLng.lng
+              "
+              >Download as JSON</a
+            >
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped></style>

--- a/components/global/IndicatorFtcCmip6.vue
+++ b/components/global/IndicatorFtcCmip6.vue
@@ -1,16 +1,84 @@
 <script lang="ts" setup>
 const placesStore = usePlacesStore()
+const mapStore = useMapStore()
 const dataStore = useDataStore()
 const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData)
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+
+const layers: MapLayer[] = [
+  {
+    id: 'indicator_ftc_historical_era',
+    title: '1980–2009, GFDL-ESM4',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_indicators',
+    style: 'ardac_indicator_ftc_historical_era',
+    legend: 'freeze_thaw_cycle',
+    rasdamanConfiguration: { dim_model: 4, dim_scenario: 0 },
+  },
+  {
+    id: 'indicator_ftc_midcentury_era',
+    title: '2040–2069, GFDL-ESM4, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_indicators',
+    style: 'ardac_indicator_ftc_midcentury_era',
+    legend: 'freeze_thaw_cycle',
+    rasdamanConfiguration: { dim_model: 4, dim_scenario: 4 },
+  },
+  {
+    id: 'indicator_rx5day_latecentury_era',
+    title: '2070–2099, GFDL-ESM4, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_indicators',
+    style: 'ardac_indicator_ftc_latecentury_era',
+    legend: 'freeze_thaw_cycle',
+    rasdamanConfiguration: { dim_model: 4, dim_scenario: 4 },
+  },
+]
+
+const legend: Record<string, LegendItem[]> = {
+  freeze_thaw_cycle: [
+    { color: '#f7f7f7', label: '&ge;1 day, &lt;20 days' },
+    { color: '#cccccc', label: '&ge;20 days, &lt;40 days' },
+    { color: '#969696', label: '&ge;40 days, &lt;60 days' },
+    { color: '#636363', label: '&ge;60 days, &lt;80 days' },
+    { color: '#252525', label: '&ge;80 days' },
+  ],
+}
+
+const mapId = 'freeze_thaw_cycle'
+mapStore.setLegendItems(mapId, legend)
 </script>
 
 <template>
   <section class="section">
     <div class="content is-size-5">
       <h3 class="title is-3">Freeze/Thaw Cycle</h3>
+      <p class="mb-6">
+        Freeze/thaw cycle is the number of days where maximum daily temperatures
+        are above freezing and minimum daily temperatures are at or below
+        freezing. The map below shows the 30-year mean of CMIP6 freeze/thaw
+        cycle for three eras. The historical era (1980&ndash;2009) uses
+        historical modeled data provided by the GFDL-ESM4 model. The mid-century
+        (2040&ndash;2069) and late-century (2070&ndash;2099) eras use modeled
+        projections from the GFDL-ESM4 model under the SSP5-8.5 emissions
+        scenario.
+      </p>
+
+      <MapBlock :mapId="mapId" class="mb-6">
+        <template v-slot:layers>
+          <MapLayer :mapId="mapId" :layer="layers[0]" default>
+            <template v-slot:title>{{ layers[0].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[1]">
+            <template v-slot:title>{{ layers[1].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[2]">
+            <template v-slot:title>{{ layers[2].title }}</template>
+          </MapLayer>
+        </template>
+      </MapBlock>
 
       <p>
         Enter lat/lon coordinates below to see a chart of freeze/thaw cycle days

--- a/components/global/IndicatorRx1day.vue
+++ b/components/global/IndicatorRx1day.vue
@@ -51,7 +51,7 @@ mapStore.setLegendItems(mapId, legend)
 <template>
   <section class="section">
     <div class="content is-size-5">
-      <h3 class="title is-3">Maximum 1-day Precipitation</h3>
+      <h3 class="title is-3">Maximum 1-day Precipitation, CMIP6</h3>
       <p class="mb-6">
         The map below shows the 30-year mean of the maximum 1-day precipitation
         for three eras. The historical era (1980&ndash;2009) uses historical

--- a/components/global/IndicatorRx1day.vue
+++ b/components/global/IndicatorRx1day.vue
@@ -51,7 +51,7 @@ mapStore.setLegendItems(mapId, legend)
 <template>
   <section class="section">
     <div class="content is-size-5">
-      <h3 class="title is-3">Maximum 1-day Precipitation, CMIP6</h3>
+      <h3 class="title is-3">Maximum 1-day Precipitation</h3>
       <p class="mb-6">
         The map below shows the 30-year mean of the maximum 1-day precipitation
         for three eras. The historical era (1980&ndash;2009) uses historical

--- a/components/global/IndicatorRx1dayCmip6.vue
+++ b/components/global/IndicatorRx1dayCmip6.vue
@@ -1,0 +1,74 @@
+<script lang="ts" setup>
+const placesStore = usePlacesStore()
+const dataStore = useDataStore()
+const runtimeConfig = useRuntimeConfig()
+
+const apiData = computed<Record<string, any>>(() => dataStore.apiData)
+const latLng = computed<LatLngValue>(() => placesStore.latLng)
+</script>
+
+<template>
+  <section class="section">
+    <div class="content is-size-5">
+      <h3 class="title is-3">Maximum 1-day Precipitation, CMIP6</h3>
+
+      <p>
+        Enter lat/lon coordinates below to see a chart of maximum 1-day
+        precipitation for a point location. This chart displays annual
+        min/mean/max values for modeled historical and projected decades for ten
+        models and four scenarios. After entering lat/lon coordinates, links
+        will be provided where you can download the data that is used to
+        populate the chart.
+      </p>
+
+      <Gimme />
+      <IndicatorsCmip6ChartControls />
+      <IndicatorsCmip6Chart
+        label="Maximum 1-day precipitation"
+        units="㎜"
+        dataKey="rx1day"
+      />
+
+      <div v-if="latLng && apiData" class="my-6">
+        <h4 class="title is-4">
+          Download maximum 1-day precipitation data for {{ latLng.lat }},
+          {{ latLng.lng }}
+        </h4>
+        <p>
+          The following download links bundle maximum 1-day precipitation data
+          with other climate indicators. Maximum 1-day precipitation uses the
+          "rx1day" identifier.
+        </p>
+        <ul>
+          <li>
+            <a
+              :href="
+                runtimeConfig.public.apiUrl +
+                '/indicators/cmip6/point/' +
+                latLng.lat +
+                '/' +
+                latLng.lng +
+                '?format=csv'
+              "
+              >Download as CSV</a
+            >
+          </li>
+          <li>
+            <a
+              :href="
+                runtimeConfig.public.apiUrl +
+                '/indicators/cmip6/point/' +
+                latLng.lat +
+                '/' +
+                latLng.lng
+              "
+              >Download as JSON</a
+            >
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped></style>

--- a/components/global/IndicatorRx1dayCmip6.vue
+++ b/components/global/IndicatorRx1dayCmip6.vue
@@ -1,16 +1,82 @@
 <script lang="ts" setup>
 const placesStore = usePlacesStore()
+const mapStore = useMapStore()
 const dataStore = useDataStore()
 const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData)
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+
+const layers: MapLayer[] = [
+  {
+    id: 'indicator_rx1day_historical_era',
+    title: '1980–2009, GFDL-ESM4',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_indicators',
+    style: 'ardac_indicator_rx1day_historical_era',
+    legend: 'rx1day',
+    rasdamanConfiguration: { dim_model: 4, dim_scenario: 0 },
+  },
+  {
+    id: 'indicator_rx1day_midcentury_era',
+    title: '2040–2069, GFDL-ESM4, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_indicators',
+    style: 'ardac_indicator_rx1day_midcentury_era',
+    legend: 'rx1day',
+    rasdamanConfiguration: { dim_model: 4, dim_scenario: 4 },
+  },
+  {
+    id: 'indicator_rx1day_latecentury_era',
+    title: '2070–2099, GFDL-ESM4, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_indicators',
+    style: 'ardac_indicator_rx1day_latecentury_era',
+    legend: 'rx1day',
+    rasdamanConfiguration: { dim_model: 4, dim_scenario: 4 },
+  },
+]
+
+const legend: Record<string, LegendItem[]> = {
+  rx1day: [
+    { color: '#edf8fb', label: '&ge;0㎜, &lt;20㎜' },
+    { color: '#b2e2e2', label: '&ge;20㎜, &lt;40㎜' },
+    { color: '#66c2a4', label: '&ge;40㎜, &lt;60㎜' },
+    { color: '#2ca25f', label: '&ge;60㎜, &lt;80㎜' },
+    { color: '#006d2c', label: '&ge;80㎜' },
+  ],
+}
+
+const mapId = 'maximum_1_day_precipitation'
+mapStore.setLegendItems(mapId, legend)
 </script>
 
 <template>
   <section class="section">
     <div class="content is-size-5">
       <h3 class="title is-3">Maximum 1-day Precipitation, CMIP6</h3>
+      <p class="mb-6">
+        The map below shows the 30-year mean of CMIP6 maximum 1-day
+        precipitation for three eras. The historical era (1980&ndash;2009) uses
+        historical modeled data provided by the GFDL-ESM4 model. The mid-century
+        (2040&ndash;2069) and late-century (2070&ndash;2099) eras use modeled
+        projections from the GFDL-ESM4 model under the SSP5-8.5 emissions
+        scenario.
+      </p>
+
+      <MapBlock :mapId="mapId" class="mb-6">
+        <template v-slot:layers>
+          <MapLayer :mapId="mapId" :layer="layers[0]" default>
+            <template v-slot:title>{{ layers[0].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[1]">
+            <template v-slot:title>{{ layers[1].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[2]">
+            <template v-slot:title>{{ layers[2].title }}</template>
+          </MapLayer>
+        </template>
+      </MapBlock>
 
       <p>
         Enter lat/lon coordinates below to see a chart of maximum 1-day
@@ -25,7 +91,7 @@ const latLng = computed<LatLngValue>(() => placesStore.latLng)
       <IndicatorsCmip6ChartControls />
       <IndicatorsCmip6Chart
         label="Maximum 1-day precipitation"
-        units="㎜"
+        units="m"
         dataKey="rx1day"
       />
 

--- a/components/global/IndicatorSuCmip6.vue
+++ b/components/global/IndicatorSuCmip6.vue
@@ -27,7 +27,7 @@ const layers: MapLayer[] = [
     rasdamanConfiguration: { dim_model: 4, dim_scenario: 4 },
   },
   {
-    id: 'indicator_rx5day_latecentury_era',
+    id: 'indicator_su_latecentury_era',
     title: '2070–2099, GFDL-ESM4, SSP5-8.5',
     source: 'rasdaman',
     wmsLayerName: 'cmip6_indicators',
@@ -56,8 +56,9 @@ mapStore.setLegendItems(mapId, legend)
     <div class="content is-size-5">
       <h3 class="title is-3">Summer Days, CMIP6</h3>
       <p class="mb-6">
-        The map below shows the 30-year mean of CMIP6 summer days for three
-        eras. The historical era (1980&ndash;2009) uses historical modeled data
+        Summer days are the number of days per year that are above 77&deg;F. The
+        map below shows the 30-year mean of CMIP6 summer days for three eras.
+        The historical era (1980&ndash;2009) uses historical modeled data
         provided by the GFDL-ESM4 model. The mid-century (2040&ndash;2069) and
         late-century (2070&ndash;2099) eras use modeled projections from the
         GFDL-ESM4 model under the SSP5-8.5 emissions scenario.

--- a/components/global/IndicatorSuCmip6.vue
+++ b/components/global/IndicatorSuCmip6.vue
@@ -1,10 +1,35 @@
 <script lang="ts" setup>
 const placesStore = usePlacesStore()
+const mapStore = useMapStore()
 const dataStore = useDataStore()
 const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData)
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+
+const layers: MapLayer[] = [
+  {
+    id: 'indicator_su_historical_era',
+    title: '1980–2009, CNRM-CM6-1-HR',
+    source: 'rasdaman',
+    wmsLayerName: 'new_cmip6_indicators',
+    style: 'ardac_indicator_su_historical_era',
+    legend: 'su',
+  },
+]
+
+const legend: Record<string, LegendItem[]> = {
+  su: [
+    // { color: '#edf8fb', label: '&ge;0㎜, &lt;10㎜' },
+    // { color: '#b2e2e2', label: '&ge;10㎜, &lt;20㎜' },
+    // { color: '#66c2a4', label: '&ge;20㎜, &lt;30㎜' },
+    // { color: '#2ca25f', label: '&ge;30㎜, &lt;40㎜' },
+    // { color: '#006d2c', label: '&ge;40㎜' },
+  ],
+}
+
+const mapId = 'su'
+mapStore.setLegendItems(mapId, legend)
 </script>
 
 <template>
@@ -19,6 +44,14 @@ const latLng = computed<LatLngValue>(() => placesStore.latLng)
         scenarios. After entering lat/lon coordinates, links will be provided
         where you can download the data that is used to populate the chart.
       </p>
+
+      <MapBlock :mapId="mapId" class="mb-6">
+        <template v-slot:layers>
+          <MapLayer :mapId="mapId" :layer="layers[0]" default>
+            <template v-slot:title>{{ layers[0].title }}</template>
+          </MapLayer>
+        </template>
+      </MapBlock>
 
       <Gimme />
       <IndicatorsCmip6ChartControls />

--- a/components/global/IndicatorSuCmip6.vue
+++ b/components/global/IndicatorSuCmip6.vue
@@ -12,42 +12,42 @@ const layers: MapLayer[] = [
     id: 'indicator_su_historical_era',
     title: '1980–2009, GFDL-ESM4',
     source: 'rasdaman',
-    wmsLayerName: 'cmip6_indicators_3338',
+    wmsLayerName: 'cmip6_indicators',
     style: 'ardac_indicator_su_historical_era',
-    legend: 'su',
+    legend: 'summer_days',
     rasdamanConfiguration: { dim_model: 4, dim_scenario: 0 },
   },
   {
     id: 'indicator_su_midcentury_era',
     title: '2040–2069, GFDL-ESM4, SSP5-8.5',
     source: 'rasdaman',
-    wmsLayerName: 'cmip6_indicators_3338',
+    wmsLayerName: 'cmip6_indicators',
     style: 'ardac_indicator_su_midcentury_era',
-    legend: 'su',
+    legend: 'summer_days',
     rasdamanConfiguration: { dim_model: 4, dim_scenario: 4 },
   },
   {
     id: 'indicator_rx5day_latecentury_era',
     title: '2070–2099, GFDL-ESM4, SSP5-8.5',
     source: 'rasdaman',
-    wmsLayerName: 'cmip6_indicators_3338',
+    wmsLayerName: 'cmip6_indicators',
     style: 'ardac_indicator_su_latecentury_era',
-    legend: 'su',
+    legend: 'summer_days',
     rasdamanConfiguration: { dim_model: 4, dim_scenario: 4 },
   },
 ]
 
 const legend: Record<string, LegendItem[]> = {
-  su: [
-    // { color: '#edf8fb', label: '&ge;0㎜, &lt;10㎜' },
-    // { color: '#b2e2e2', label: '&ge;10㎜, &lt;20㎜' },
-    // { color: '#66c2a4', label: '&ge;20㎜, &lt;30㎜' },
-    // { color: '#2ca25f', label: '&ge;30㎜, &lt;40㎜' },
-    // { color: '#006d2c', label: '&ge;40㎜' },
+  summer_days: [
+    { color: '#fdd0a2', label: '&ge;1 day, &lt;5 days' },
+    { color: '#fdae6b', label: '&ge;5 days, &lt;10 days' },
+    { color: '#fd8d3c', label: '&ge;10 days, &lt;20 days' },
+    { color: '#e6550d', label: '&ge;20 days, &lt;40 days' },
+    { color: '#a63603', label: '&ge;40 days' },
   ],
 }
 
-const mapId = 'su'
+const mapId = 'summer_days'
 mapStore.setLegendItems(mapId, legend)
 </script>
 

--- a/components/global/IndicatorSuCmip6.vue
+++ b/components/global/IndicatorSuCmip6.vue
@@ -10,11 +10,30 @@ const latLng = computed<LatLngValue>(() => placesStore.latLng)
 const layers: MapLayer[] = [
   {
     id: 'indicator_su_historical_era',
-    title: '1980–2009, CNRM-CM6-1-HR',
+    title: '1980–2009, GFDL-ESM4',
     source: 'rasdaman',
-    wmsLayerName: 'new_cmip6_indicators',
+    wmsLayerName: 'cmip6_indicators_3338',
     style: 'ardac_indicator_su_historical_era',
     legend: 'su',
+    rasdamanConfiguration: { dim_model: 4, dim_scenario: 0 },
+  },
+  {
+    id: 'indicator_su_midcentury_era',
+    title: '2040–2069, GFDL-ESM4, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_indicators_3338',
+    style: 'ardac_indicator_su_midcentury_era',
+    legend: 'su',
+    rasdamanConfiguration: { dim_model: 4, dim_scenario: 4 },
+  },
+  {
+    id: 'indicator_rx5day_latecentury_era',
+    title: '2070–2099, GFDL-ESM4, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_indicators_3338',
+    style: 'ardac_indicator_su_latecentury_era',
+    legend: 'su',
+    rasdamanConfiguration: { dim_model: 4, dim_scenario: 4 },
   },
 ]
 
@@ -36,13 +55,12 @@ mapStore.setLegendItems(mapId, legend)
   <section class="section">
     <div class="content is-size-5">
       <h3 class="title is-3">Summer Days, CMIP6</h3>
-
-      <p>
-        Enter lat/lon coordinates below to see a chart of summer days for a
-        point location. This chart displays annual min/mean/max values for
-        modeled historical and projected decades for ten models and four
-        scenarios. After entering lat/lon coordinates, links will be provided
-        where you can download the data that is used to populate the chart.
+      <p class="mb-6">
+        The map below shows the 30-year mean of CMIP6 summer days for three
+        eras. The historical era (1980&ndash;2009) uses historical modeled data
+        provided by the GFDL-ESM4 model. The mid-century (2040&ndash;2069) and
+        late-century (2070&ndash;2099) eras use modeled projections from the
+        GFDL-ESM4 model under the SSP5-8.5 emissions scenario.
       </p>
 
       <MapBlock :mapId="mapId" class="mb-6">
@@ -50,8 +68,22 @@ mapStore.setLegendItems(mapId, legend)
           <MapLayer :mapId="mapId" :layer="layers[0]" default>
             <template v-slot:title>{{ layers[0].title }}</template>
           </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[1]">
+            <template v-slot:title>{{ layers[1].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[2]">
+            <template v-slot:title>{{ layers[2].title }}</template>
+          </MapLayer>
         </template>
       </MapBlock>
+
+      <p>
+        Enter lat/lon coordinates below to see a chart of CMIP6 summer days for
+        a point location. This chart displays annual min/mean/max values for
+        modeled historical and projected decades for ten models and four
+        scenarios. After entering lat/lon coordinates, links will be provided
+        where you can download the data that is used to populate the chart.
+      </p>
 
       <Gimme />
       <IndicatorsCmip6ChartControls />
@@ -59,11 +91,11 @@ mapStore.setLegendItems(mapId, legend)
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download summer days data for {{ latLng.lat }},
+          Download CMIP6 summer days data for {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <p>
-          The following download links bundle summer days data with other
+          The following download links bundle summer days data with other CMIP6
           climate indicators. Summer days use the "su" identifier.
         </p>
         <ul>

--- a/components/global/IndicatorSuCmip6.vue
+++ b/components/global/IndicatorSuCmip6.vue
@@ -1,0 +1,68 @@
+<script lang="ts" setup>
+const placesStore = usePlacesStore()
+const dataStore = useDataStore()
+const runtimeConfig = useRuntimeConfig()
+
+const apiData = computed<Record<string, any>>(() => dataStore.apiData)
+const latLng = computed<LatLngValue>(() => placesStore.latLng)
+</script>
+
+<template>
+  <section class="section">
+    <div class="content is-size-5">
+      <h3 class="title is-3">Summer Days, CMIP6</h3>
+
+      <p>
+        Enter lat/lon coordinates below to see a chart of summer days for a
+        point location. This chart displays annual min/mean/max values for
+        modeled historical and projected decades for ten models and four
+        scenarios. After entering lat/lon coordinates, links will be provided
+        where you can download the data that is used to populate the chart.
+      </p>
+
+      <Gimme />
+      <IndicatorsCmip6ChartControls />
+      <IndicatorsCmip6Chart label="Summer days" dataKey="su" />
+
+      <div v-if="latLng && apiData" class="my-6">
+        <h4 class="title is-4">
+          Download summer days data for {{ latLng.lat }},
+          {{ latLng.lng }}
+        </h4>
+        <p>
+          The following download links bundle summer days data with other
+          climate indicators. Summer days use the "su" identifier.
+        </p>
+        <ul>
+          <li>
+            <a
+              :href="
+                runtimeConfig.public.apiUrl +
+                '/indicators/cmip6/point/' +
+                latLng.lat +
+                '/' +
+                latLng.lng +
+                '?format=csv'
+              "
+              >Download as CSV</a
+            >
+          </li>
+          <li>
+            <a
+              :href="
+                runtimeConfig.public.apiUrl +
+                '/indicators/cmip6/point/' +
+                latLng.lat +
+                '/' +
+                latLng.lng
+              "
+              >Download as JSON</a
+            >
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped></style>

--- a/stores/chart.ts
+++ b/stores/chart.ts
@@ -1,0 +1,13 @@
+import { defineStore } from 'pinia'
+
+export const useChartStore = defineStore('chart', () => {
+  // We can support additional options/params types here as needed if we end up
+  // using this store for other types of charts, not just hydrology.
+  let labels: Ref<IndicatorsCmip6ChartLabelsObj> = ref(undefined)
+  let inputs: Ref<IndicatorsCmip6ChartInputsObj> = ref(undefined)
+
+  return {
+    labels,
+    inputs,
+  }
+})

--- a/stores/data.ts
+++ b/stores/data.ts
@@ -4,6 +4,7 @@ const placesStore = usePlacesStore()
 
 const endpoints: Record<string, string> = {
   beetles: '/beetles/point/',
+  indicatorsCmip6: '/indicators/cmip6/point/',
   degreeDaysBelow0: '/degree_days/below_zero/',
   heatingDegreeDays: '/degree_days/heating/',
   indicators: '/indicators/base/point/',

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -9,13 +9,13 @@ interface Item {
 }
 
 interface Community {
-  id: string,
-  name: string,
-  alt_name?: string,
-  region: string,
-  country: string,
-  latitude: number,
-  longitude: number,
+  id: string
+  name: string
+  alt_name?: string
+  region: string
+  country: string
+  latitude: number
+  longitude: number
   type: string
 }
 
@@ -47,6 +47,19 @@ interface LatLng {
   lng: number
 }
 
+interface IndicatorsCmip6ChartLabels {
+  models: Record<string, string>
+  scenarios: Record<string, string>
+}
+
+interface IndicatorsCmip6ChartInputs {
+  model: string
+  scenario: string
+}
+
 type LatLngValue = LatLng | undefined
 
 type PlaceType = 'community' | 'latLng' | undefined
+
+type IndicatorsCmip6ChartLabelsObj = IndicatorsCmip6ChartLabels | undefined
+type IndicatorsCmip6ChartInputsObj = IndicatorsCmip6ChartInputs | undefined

--- a/types/slugs.d.ts
+++ b/types/slugs.d.ts
@@ -1,5 +1,4 @@
 type Slug =
-  | 'indicator-ftc'
   | 'indicator-su'
   | 'indicator-dw'
   | 'indicator-hd'
@@ -58,3 +57,7 @@ type Slug =
   | 'hydrology-cmip6'
   | 'solar-radiation-cloud-cover-cmip6'
   | 'snow-cmip6'
+  | 'indicator-ftc-cmip6'
+  | 'indicator-su-cmip6'
+  | 'indicator-dw-cmip6'
+  | 'indicator-rx1day-cmip6'


### PR DESCRIPTION
This PR consists of the maps + charts of the following CMIP6 variables available through our development API:

- Freeze/Thaw Cycle
- Summer Days
- Deep Winter Days
- Maximum 1-day Precipitation

To test, run a local instance of the Data API from the `cmip6_indicators` branch, pointing at Zeus:

```
cd data-api
git checkout cmip6_indicators
git pull --ff-only
export FLASK_APP=application.py
export API_RAS_BASE_URL=https://zeus.snap.uaf.edu/rasdaman/
pipenv run flask run
```

Then run this branch of the ARDAC Explorer against the local API, and against Zeus for its Rasdaman server:

```
cd ardac-explorer
git checkout implement_cmip6_items
export SNAP_API_URL=http://localhost:5000
export RASDAMAN_URL=https://zeus.snap.uaf.edu/rasdaman/ows
npm run dev
```

Then view the available CMIP6 items here:

http://localhost:3000/item/indicator-ftc-cmip6
http://localhost:3000/item/indicator-su-cmip6
http://localhost:3000/item/indicator-dw-cmip6
http://localhost:3000/item/indicator-rx1day-cmip6