### PR TITLE
Update degree-days-based items to work with new coverages & API output

### DIFF
--- a/components/DegreeDaysChart.vue
+++ b/components/DegreeDaysChart.vue
@@ -24,8 +24,10 @@ const getPlotValues = (minYear: number, maxYear: number, model: string) => {
 
   let degreeDays: number[] = []
 
+  let scenario = model === 'daymet' ? 'historical' : 'rcp85'
+
   years.forEach((year: number) => {
-    degreeDays.push(chartData[model][year]['dd'])
+    degreeDays.push(chartData[model][scenario][year]['dd'])
   })
 
   // Group yearly values into decade buckets to make it easier to calculate
@@ -92,32 +94,32 @@ const buildChart = () => {
 
     let traceParams = [
       {
-        model: 'ERA-Interim',
+        model: 'daymet',
         minYear: 1980,
         maxYear: 2009,
       },
       {
-        model: 'GFDL-CM3',
+        model: 'GFDL-ESM2M',
         minYear: 2010,
         maxYear: 2099,
       },
       {
-        model: 'NCAR-CCSM4',
+        model: 'CCSM4',
         minYear: 2010,
         maxYear: 2099,
       },
     ]
 
     let symbols: Record<string, string> = {
-      'ERA-Interim': 'circle',
-      'GFDL-CM3': 'square',
-      'NCAR-CCSM4': 'diamond',
+      daymet: 'circle',
+      'GFDL-ESM2M': 'square',
+      CCSM4: 'diamond',
     }
 
     let offsets: Record<string, number> = {
-      'ERA-Interim': 0,
-      'GFDL-CM3': -0.15,
-      'NCAR-CCSM4': 0.15,
+      daymet: 0,
+      'GFDL-ESM2M': -0.15,
+      CCSM4: 0.15,
     }
 
     traceParams.forEach(params => {

--- a/components/global/DdBelow0.vue
+++ b/components/global/DdBelow0.vue
@@ -15,6 +15,7 @@ const layers: MapLayer[] = [
     wmsLayerName: 'degree_days_below_zero_Fdays',
     style: 'ardac_dd_below_0_historical_era',
     legend: 'dd_below_0',
+    rasdamanConfiguration: { dim_model: 0, dim_scenario: 0 },
   },
   {
     id: 'dd_below_0_midcentury_era',
@@ -23,6 +24,7 @@ const layers: MapLayer[] = [
     wmsLayerName: 'degree_days_below_zero_Fdays',
     style: 'ardac_dd_below_0_midcentury_era',
     legend: 'dd_below_0',
+    rasdamanConfiguration: { dim_model: 2, dim_scenario: 2 },
   },
   {
     id: 'dd_below_0_latecentury_era',
@@ -31,6 +33,7 @@ const layers: MapLayer[] = [
     wmsLayerName: 'degree_days_below_zero_Fdays',
     style: 'ardac_dd_below_0_latecentury_era',
     legend: 'dd_below_0',
+    rasdamanConfiguration: { dim_model: 2, dim_scenario: 2 },
   },
 ]
 

--- a/components/global/DdBelow0.vue
+++ b/components/global/DdBelow0.vue
@@ -12,7 +12,7 @@ const layers: MapLayer[] = [
     id: 'dd_below_0_historical_era',
     title: '1980–2009, Daymet',
     source: 'rasdaman',
-    wmsLayerName: 'degree_days_below_zero',
+    wmsLayerName: 'degree_days_below_zero_Fdays',
     style: 'ardac_dd_below_0_historical_era',
     legend: 'dd_below_0',
   },
@@ -20,7 +20,7 @@ const layers: MapLayer[] = [
     id: 'dd_below_0_midcentury_era',
     title: '2040–2069, NCAR CCSM4, RCP 8.5',
     source: 'rasdaman',
-    wmsLayerName: 'degree_days_below_zero',
+    wmsLayerName: 'degree_days_below_zero_Fdays',
     style: 'ardac_dd_below_0_midcentury_era',
     legend: 'dd_below_0',
   },
@@ -28,7 +28,7 @@ const layers: MapLayer[] = [
     id: 'dd_below_0_latecentury_era',
     title: '2070–2099, NCAR CCSM4, RCP 8.5',
     source: 'rasdaman',
-    wmsLayerName: 'degree_days_below_zero',
+    wmsLayerName: 'degree_days_below_zero_Fdays',
     style: 'ardac_dd_below_0_latecentury_era',
     legend: 'dd_below_0',
   },
@@ -55,10 +55,9 @@ mapStore.setLegendItems(mapId, legend)
       <p class="mb-6">
         The map below shows the 30-year mean of degree days below 0&deg;F for
         three eras. The historical era (1980&ndash;2009) uses historical modeled
-        data provided by the ERA-Interim model. The mid-century
-        (2040&ndash;2069) and late-century (2070&ndash;2099) eras use modeled
-        projections from the NCAR CCSM4 model under the RCP 8.5 emissions
-        scenario.
+        data provided by Daymet. The mid-century (2040&ndash;2069) and
+        late-century (2070&ndash;2099) eras use modeled projections from the
+        NCAR CCSM4 model under the RCP 8.5 emissions scenario.
       </p>
 
       <MapBlock :mapId="mapId" class="mb-6">
@@ -79,7 +78,7 @@ mapStore.setLegendItems(mapId, legend)
         Enter lat/lon coordinates below to see a chart of degree days below
         0&deg;F for a point location. This chart displays min/mean/max values
         for historical decades using the ERA-Interim model and projected decades
-        using both the GFDL CM3 and NCAR CCSM4 models under the RCP 8.5
+        using both the GFDL ESM2M and NCAR CCSM4 models under the RCP 8.5
         emissions scenario.
       </p>
 

--- a/components/global/DdBelow0.vue
+++ b/components/global/DdBelow0.vue
@@ -77,7 +77,7 @@ mapStore.setLegendItems(mapId, legend)
       <p>
         Enter lat/lon coordinates below to see a chart of degree days below
         0&deg;F for a point location. This chart displays min/mean/max values
-        for historical decades using the ERA-Interim model and projected decades
+        for historical decades using the Daymet model and projected decades
         using both the GFDL ESM2M and NCAR CCSM4 models under the RCP 8.5
         emissions scenario.
       </p>

--- a/components/global/DdBelow65.vue
+++ b/components/global/DdBelow65.vue
@@ -79,7 +79,7 @@ mapStore.setLegendItems(mapId, legend)
       <p>
         Enter lat/lon coordinates below to see a chart of degree days below
         65&deg;F for a point location. This chart displays min/mean/max values
-        for historical decades using the ERA-Interim model and projected decades
+        for historical decades using the Daymet model and projected decades
         using both the GFDL ESM2M and NCAR CCSM4 models under the RCP 8.5
         emissions scenario.
       </p>

--- a/components/global/DdBelow65.vue
+++ b/components/global/DdBelow65.vue
@@ -15,6 +15,7 @@ const layers: MapLayer[] = [
     wmsLayerName: 'heating_degree_days_Fdays',
     style: 'ardac_dd_below_65_historical_era',
     legend: 'dd_below_65',
+    rasdamanConfiguration: { dim_model: 0, dim_scenario: 0 },
   },
   {
     id: 'dd_below_65_midcentury_era',
@@ -23,6 +24,7 @@ const layers: MapLayer[] = [
     wmsLayerName: 'heating_degree_days_Fdays',
     style: 'ardac_dd_below_65_midcentury_era',
     legend: 'dd_below_65',
+    rasdamanConfiguration: { dim_model: 2, dim_scenario: 2 },
   },
   {
     id: 'dd_below_65_latecentury_era',
@@ -31,6 +33,7 @@ const layers: MapLayer[] = [
     wmsLayerName: 'heating_degree_days_Fdays',
     style: 'ardac_dd_below_65_latecentury_era',
     legend: 'dd_below_65',
+    rasdamanConfiguration: { dim_model: 2, dim_scenario: 2 },
   },
 ]
 

--- a/components/global/DdBelow65.vue
+++ b/components/global/DdBelow65.vue
@@ -12,7 +12,7 @@ const layers: MapLayer[] = [
     id: 'dd_below_65_historical_era',
     title: '1980–2009, Daymet',
     source: 'rasdaman',
-    wmsLayerName: 'heating_degree_days',
+    wmsLayerName: 'heating_degree_days_Fdays',
     style: 'ardac_dd_below_65_historical_era',
     legend: 'dd_below_65',
   },
@@ -20,7 +20,7 @@ const layers: MapLayer[] = [
     id: 'dd_below_65_midcentury_era',
     title: '2040–2069, NCAR CCSM4, RCP 8.5',
     source: 'rasdaman',
-    wmsLayerName: 'heating_degree_days',
+    wmsLayerName: 'heating_degree_days_Fdays',
     style: 'ardac_dd_below_65_midcentury_era',
     legend: 'dd_below_65',
   },
@@ -28,7 +28,7 @@ const layers: MapLayer[] = [
     id: 'dd_below_65_latecentury_era',
     title: '2070–2099, NCAR CCSM4, RCP 8.5',
     source: 'rasdaman',
-    wmsLayerName: 'heating_degree_days',
+    wmsLayerName: 'heating_degree_days_Fdays',
     style: 'ardac_dd_below_65_latecentury_era',
     legend: 'dd_below_65',
   },
@@ -57,9 +57,9 @@ mapStore.setLegendItems(mapId, legend)
         to approximate the energy needed to heat a building in a given year. The
         map below shows the 30-year mean of degree bays below 65&deg;F for three
         eras. The historical era (1980&ndash;2009) uses historical modeled data
-        provided by the ERA-Interim model. The mid-century (2040&ndash;2069) and
-        late-century (2070&ndash;2099) eras use modeled projections from the
-        NCAR CCSM4 model under the RCP 8.5 emissions scenario.
+        provided by Daymet. The mid-century (2040&ndash;2069) and late-century
+        (2070&ndash;2099) eras use modeled projections from the NCAR CCSM4 model
+        under the RCP 8.5 emissions scenario.
       </p>
 
       <MapBlock :mapId="mapId" class="mb-6">
@@ -80,7 +80,7 @@ mapStore.setLegendItems(mapId, legend)
         Enter lat/lon coordinates below to see a chart of degree days below
         65&deg;F for a point location. This chart displays min/mean/max values
         for historical decades using the ERA-Interim model and projected decades
-        using both the GFDL CM3 and NCAR CCSM4 models under the RCP 8.5
+        using both the GFDL ESM2M and NCAR CCSM4 models under the RCP 8.5
         emissions scenario.
       </p>
 

--- a/components/global/FreezingIndex.vue
+++ b/components/global/FreezingIndex.vue
@@ -15,6 +15,7 @@ const layers: MapLayer[] = [
     wmsLayerName: 'air_freezing_index_Fdays',
     style: 'ardac_freezing_index_historical_era',
     legend: 'freezing_index',
+    rasdamanConfiguration: { dim_model: 0, dim_scenario: 0 },
   },
   {
     id: 'freezing_index_midcentury_era',
@@ -23,6 +24,7 @@ const layers: MapLayer[] = [
     wmsLayerName: 'air_freezing_index_Fdays',
     style: 'ardac_freezing_index_midcentury_era',
     legend: 'freezing_index',
+    rasdamanConfiguration: { dim_model: 2, dim_scenario: 2 },
   },
   {
     id: 'freezing_index_latecentury_era',
@@ -31,6 +33,7 @@ const layers: MapLayer[] = [
     wmsLayerName: 'air_freezing_index_Fdays',
     style: 'ardac_freezing_index_latecentury_era',
     legend: 'freezing_index',
+    rasdamanConfiguration: { dim_model: 2, dim_scenario: 2 },
   },
 ]
 

--- a/components/global/FreezingIndex.vue
+++ b/components/global/FreezingIndex.vue
@@ -78,8 +78,8 @@ mapStore.setLegendItems(mapId, legend)
       <p>
         Enter lat/lon coordinates below to see a chart of the freezing index for
         a point location. This chart displays min/mean/max values for historical
-        decades using the ERA-Interim model and projected decades using both the
-        GFDL ESM2M and NCAR CCSM4 models under the RCP 8.5 emissions scenario.
+        decades using the Daymet model and projected decades using both the GFDL
+        ESM2M and NCAR CCSM4 models under the RCP 8.5 emissions scenario.
       </p>
 
       <p>

--- a/components/global/FreezingIndex.vue
+++ b/components/global/FreezingIndex.vue
@@ -12,7 +12,7 @@ const layers: MapLayer[] = [
     id: 'freezing_index_historical_era',
     title: '1980–2009, Daymet',
     source: 'rasdaman',
-    wmsLayerName: 'freezing_index',
+    wmsLayerName: 'air_freezing_index_Fdays',
     style: 'ardac_freezing_index_historical_era',
     legend: 'freezing_index',
   },
@@ -20,7 +20,7 @@ const layers: MapLayer[] = [
     id: 'freezing_index_midcentury_era',
     title: '2040–2069, NCAR CCSM4, RCP 8.5',
     source: 'rasdaman',
-    wmsLayerName: 'freezing_index',
+    wmsLayerName: 'air_freezing_index_Fdays',
     style: 'ardac_freezing_index_midcentury_era',
     legend: 'freezing_index',
   },
@@ -28,7 +28,7 @@ const layers: MapLayer[] = [
     id: 'freezing_index_latecentury_era',
     title: '2070–2099, NCAR CCSM4, RCP 8.5',
     source: 'rasdaman',
-    wmsLayerName: 'freezing_index',
+    wmsLayerName: 'air_freezing_index_Fdays',
     style: 'ardac_freezing_index_latecentury_era',
     legend: 'freezing_index',
   },
@@ -56,9 +56,9 @@ mapStore.setLegendItems(mapId, legend)
         The freezing index is the number of degree days above freezing per year.
         The map below shows the 30-year mean of the freezing index for three
         eras. The historical era (1980&ndash;2009) uses historical modeled data
-        provided by the ERA-Interim model. The mid-century (2040&ndash;2069) and
-        late-century (2070&ndash;2099) eras use modeled projections from the
-        NCAR CCSM4 model under the RCP 8.5 emissions scenario.
+        provided by Daymet. The mid-century (2040&ndash;2069) and late-century
+        (2070&ndash;2099) eras use modeled projections from the NCAR CCSM4 model
+        under the RCP 8.5 emissions scenario.
       </p>
 
       <MapBlock :mapId="mapId" class="mb-6">
@@ -79,7 +79,7 @@ mapStore.setLegendItems(mapId, legend)
         Enter lat/lon coordinates below to see a chart of the freezing index for
         a point location. This chart displays min/mean/max values for historical
         decades using the ERA-Interim model and projected decades using both the
-        GFDL CM3 and NCAR CCSM4 models under the RCP 8.5 emissions scenario.
+        GFDL ESM2M and NCAR CCSM4 models under the RCP 8.5 emissions scenario.
       </p>
 
       <p>

--- a/components/global/ThawingIndex.vue
+++ b/components/global/ThawingIndex.vue
@@ -12,7 +12,7 @@ const layers: MapLayer[] = [
     id: 'thawing_index_historical_era',
     title: '1980–2009, Daymet',
     source: 'rasdaman',
-    wmsLayerName: 'thawing_index',
+    wmsLayerName: 'air_thawing_index_Fdays',
     style: 'ardac_thawing_index_historical_era',
     legend: 'thawing_index',
   },
@@ -20,7 +20,7 @@ const layers: MapLayer[] = [
     id: 'thawing_index_midcentury_era',
     title: '2040–2069, NCAR CCSM4, RCP 8.5',
     source: 'rasdaman',
-    wmsLayerName: 'thawing_index',
+    wmsLayerName: 'air_thawing_index_Fdays',
     style: 'ardac_thawing_index_midcentury_era',
     legend: 'thawing_index',
   },
@@ -28,7 +28,7 @@ const layers: MapLayer[] = [
     id: 'thawing_index_latecentury_era',
     title: '2070–2099, NCAR CCSM4, RCP 8.5',
     source: 'rasdaman',
-    wmsLayerName: 'thawing_index',
+    wmsLayerName: 'air_thawing_index_Fdays',
     style: 'ardac_thawing_index_latecentury_era',
     legend: 'thawing_index',
   },
@@ -56,9 +56,9 @@ mapStore.setLegendItems(mapId, legend)
         The thawing index is the number of degree days above freezing per year.
         The map below shows the 30-year mean of the thawing index for three
         eras. The historical era (1980&ndash;2009) uses historical modeled data
-        provided by the ERA-Interim model. The mid-century (2040&ndash;2069) and
-        late-century (2070&ndash;2099) eras use modeled projections from the
-        NCAR CCSM4 model under the RCP 8.5 emissions scenario.
+        provided by Daymet. The mid-century (2040&ndash;2069) and late-century
+        (2070&ndash;2099) eras use modeled projections from the NCAR CCSM4 model
+        under the RCP 8.5 emissions scenario.
       </p>
 
       <MapBlock :mapId="mapId" class="mb-6">
@@ -79,7 +79,7 @@ mapStore.setLegendItems(mapId, legend)
         Enter lat/lon coordinates below to see a chart of the thawing index for
         a point location. This chart displays min/mean/max values for historical
         decades using the ERA-Interim model and projected decades using both the
-        GFDL CM3 and NCAR CCSM4 models under the RCP 8.5 emissions scenario.
+        GFDL ESM2M and NCAR CCSM4 models under the RCP 8.5 emissions scenario.
       </p>
 
       <p>

--- a/components/global/ThawingIndex.vue
+++ b/components/global/ThawingIndex.vue
@@ -15,6 +15,7 @@ const layers: MapLayer[] = [
     wmsLayerName: 'air_thawing_index_Fdays',
     style: 'ardac_thawing_index_historical_era',
     legend: 'thawing_index',
+    rasdamanConfiguration: { dim_model: 0, dim_scenario: 0 },
   },
   {
     id: 'thawing_index_midcentury_era',
@@ -23,6 +24,7 @@ const layers: MapLayer[] = [
     wmsLayerName: 'air_thawing_index_Fdays',
     style: 'ardac_thawing_index_midcentury_era',
     legend: 'thawing_index',
+    rasdamanConfiguration: { dim_model: 2, dim_scenario: 2 },
   },
   {
     id: 'thawing_index_latecentury_era',
@@ -31,6 +33,7 @@ const layers: MapLayer[] = [
     wmsLayerName: 'air_thawing_index_Fdays',
     style: 'ardac_thawing_index_latecentury_era',
     legend: 'thawing_index',
+    rasdamanConfiguration: { dim_model: 2, dim_scenario: 2 },
   },
 ]
 

--- a/components/global/ThawingIndex.vue
+++ b/components/global/ThawingIndex.vue
@@ -78,8 +78,8 @@ mapStore.setLegendItems(mapId, legend)
       <p>
         Enter lat/lon coordinates below to see a chart of the thawing index for
         a point location. This chart displays min/mean/max values for historical
-        decades using the ERA-Interim model and projected decades using both the
-        GFDL ESM2M and NCAR CCSM4 models under the RCP 8.5 emissions scenario.
+        decades using the Daymet model and projected decades using both the GFDL
+        ESM2M and NCAR CCSM4 models under the RCP 8.5 emissions scenario.
       </p>
 
       <p>


### PR DESCRIPTION
This PR makes a few minor changes to the four degree-days-based ARDAC items (and their shared `DegreeDaysChart` component) to make them work against the new coverages on Zeus & new API output. The four degree-days-based ARDAC items are:

- Degree Days Below 65°F
- Degree Days Below 0°F
- Thawing Index
- Freezing Index

The existing ARDAC styles (WCPS queries + color maps) have been migrated over to the new coverages and updated with their new year index ranges, so the only thing that was left to do to update the Leaflet maps on the ARDAC Explorer side was to update the Rasdaman coverage names.

For the charts, the new coverages & API output have a different set of models than before. The NCAR CSSM4 model is still available, but I've replaced ERA-Interim with Daymet, and the GFDL-CM3 model with GFDL-ESM2M. I've also updated the intro text to reflect these changes.

To test, run a local instance of the Data API from the `main` branch, pointing at Zeus:

```
cd data-api
git checkout main
git pull --ff-only
export FLASK_APP=application.py
export API_RAS_BASE_URL=https://zeus.snap.uaf.edu/rasdaman/
pipenv run flask run
```

Then run this branch of the ARDAC Explorer against the local API, and against Zeus for its Rasdaman server:

```
cd ardac-explorer
git checkout degree_days_update
export SNAP_API_URL=http://localhost:5000
export RASDAMAN_URL=https://zeus.snap.uaf.edu/rasdaman/ows
npm run dev
```

Then check out the map layers and charts for these four ARDAC items:

http://localhost:3000/item/dd-below-65
http://localhost:3000/item/dd-below-0
http://localhost:3000/item/thawing-index
http://localhost:3000/item/freezing-index