### PR TITLE
Fix month in Landfast Sea Ice Extent intro text

### DIFF
--- a/components/global/LandfastSeaIce.vue
+++ b/components/global/LandfastSeaIce.vue
@@ -277,7 +277,7 @@ onUnmounted(() => {
     <div class="content is-size-5">
       <h3 class="title is-3">Landfast Sea Ice Extent</h3>
       <p class="mb-6">
-        The map below shows landfast sea ice extent for March 1st from
+        The map below shows landfast sea ice extent for June 1st from
         1997&ndash;2007.
       </p>
 


### PR DESCRIPTION
Closes #53.

This PR is just a simple word replacement (March → June) so that the Landfast Sea Ice Extent intro text matches the available map layers. To test, view the Landfast Sea Ice Extent ARDAC item here: http://localhost:3000/item/landfast-sea-ice