### PR TITLE
Replace "ERA-Interim" text references in degree days items with "Daymet"

### DIFF
--- a/components/global/DdBelow0.vue
+++ b/components/global/DdBelow0.vue
@@ -55,10 +55,9 @@ mapStore.setLegendItems(mapId, legend)
       <p class="mb-6">
         The map below shows the 30-year mean of degree days below 0&deg;F for
         three eras. The historical era (1980&ndash;2009) uses historical modeled
-        data provided by the ERA-Interim model. The mid-century
-        (2040&ndash;2069) and late-century (2070&ndash;2099) eras use modeled
-        projections from the NCAR CCSM4 model under the RCP 8.5 emissions
-        scenario.
+        data provided by the Daymet model. The mid-century (2040&ndash;2069) and
+        late-century (2070&ndash;2099) eras use modeled projections from the
+        NCAR CCSM4 model under the RCP 8.5 emissions scenario.
       </p>
 
       <MapBlock :mapId="mapId" class="mb-6">
@@ -78,7 +77,7 @@ mapStore.setLegendItems(mapId, legend)
       <p>
         Enter lat/lon coordinates below to see a chart of degree days below
         0&deg;F for a point location. This chart displays min/mean/max values
-        for historical decades using the ERA-Interim model and projected decades
+        for historical decades using the Daymet model and projected decades
         using both the GFDL CM3 and NCAR CCSM4 models under the RCP 8.5
         emissions scenario.
       </p>

--- a/components/global/DdBelow65.vue
+++ b/components/global/DdBelow65.vue
@@ -57,7 +57,7 @@ mapStore.setLegendItems(mapId, legend)
         to approximate the energy needed to heat a building in a given year. The
         map below shows the 30-year mean of degree bays below 65&deg;F for three
         eras. The historical era (1980&ndash;2009) uses historical modeled data
-        provided by the ERA-Interim model. The mid-century (2040&ndash;2069) and
+        provided by the Daymet model. The mid-century (2040&ndash;2069) and
         late-century (2070&ndash;2099) eras use modeled projections from the
         NCAR CCSM4 model under the RCP 8.5 emissions scenario.
       </p>
@@ -79,7 +79,7 @@ mapStore.setLegendItems(mapId, legend)
       <p>
         Enter lat/lon coordinates below to see a chart of degree days below
         65&deg;F for a point location. This chart displays min/mean/max values
-        for historical decades using the ERA-Interim model and projected decades
+        for historical decades using the Daymet model and projected decades
         using both the GFDL CM3 and NCAR CCSM4 models under the RCP 8.5
         emissions scenario.
       </p>

--- a/components/global/FreezingIndex.vue
+++ b/components/global/FreezingIndex.vue
@@ -56,7 +56,7 @@ mapStore.setLegendItems(mapId, legend)
         The freezing index is the number of degree days above freezing per year.
         The map below shows the 30-year mean of the freezing index for three
         eras. The historical era (1980&ndash;2009) uses historical modeled data
-        provided by the ERA-Interim model. The mid-century (2040&ndash;2069) and
+        provided by the Daymet model. The mid-century (2040&ndash;2069) and
         late-century (2070&ndash;2099) eras use modeled projections from the
         NCAR CCSM4 model under the RCP 8.5 emissions scenario.
       </p>
@@ -78,8 +78,8 @@ mapStore.setLegendItems(mapId, legend)
       <p>
         Enter lat/lon coordinates below to see a chart of the freezing index for
         a point location. This chart displays min/mean/max values for historical
-        decades using the ERA-Interim model and projected decades using both the
-        GFDL CM3 and NCAR CCSM4 models under the RCP 8.5 emissions scenario.
+        decades using the Daymet model and projected decades using both the GFDL
+        CM3 and NCAR CCSM4 models under the RCP 8.5 emissions scenario.
       </p>
 
       <p>

--- a/components/global/ThawingIndex.vue
+++ b/components/global/ThawingIndex.vue
@@ -56,7 +56,7 @@ mapStore.setLegendItems(mapId, legend)
         The thawing index is the number of degree days above freezing per year.
         The map below shows the 30-year mean of the thawing index for three
         eras. The historical era (1980&ndash;2009) uses historical modeled data
-        provided by the ERA-Interim model. The mid-century (2040&ndash;2069) and
+        provided by the Daymet model. The mid-century (2040&ndash;2069) and
         late-century (2070&ndash;2099) eras use modeled projections from the
         NCAR CCSM4 model under the RCP 8.5 emissions scenario.
       </p>
@@ -78,8 +78,8 @@ mapStore.setLegendItems(mapId, legend)
       <p>
         Enter lat/lon coordinates below to see a chart of the thawing index for
         a point location. This chart displays min/mean/max values for historical
-        decades using the ERA-Interim model and projected decades using both the
-        GFDL CM3 and NCAR CCSM4 models under the RCP 8.5 emissions scenario.
+        decades using the Daymet model and projected decades using both the GFDL
+        CM3 and NCAR CCSM4 models under the RCP 8.5 emissions scenario.
       </p>
 
       <p>


### PR DESCRIPTION
Closes #86.

This PR simply replaces all "ERA-Interim" references in the intro/explanatory text of degree days items with "Daymet".

To test, make sure there are no references to "ERA-Interim" on the following items:

http://localhost:3000/item/dd-below-65
http://localhost:3000/item/dd-below-0
http://localhost:3000/item/thawing-index
http://localhost:3000/item/freezing-index