### PR TITLE
Fix year range in intro text of Sea Ice Concentration item

### DIFF
--- a/components/global/SeaIceConcentration.vue
+++ b/components/global/SeaIceConcentration.vue
@@ -201,7 +201,7 @@ onUnmounted(() => {
       <h3 class="title is-3">Sea Ice Concentration</h3>
       <p class="mb-6">
         The map below shows pan-Arctic sea ice concentration for March at
-        25-year intervals from 1980&ndash;2000.
+        25-year intervals from 1850&ndash;2000.
       </p>
 
       <MapBlock :mapId="mapId" class="mb-6">


### PR DESCRIPTION
Closes #76.

This PR simply replaces the "1980-2000" year range in the intro text of the Sea Ice Concentration item with "1850-2000" to accurately reflect the displayed map layers.

To test, look at the Sea Ice Concentration here and verify the above:

http://localhost:3000/item/sea-ice-concentration