### PR TITLE
Add Natural Earth coastline layer to problematic maps

### DIFF
--- a/components/global/IndicatorFtcCmip6.vue
+++ b/components/global/IndicatorFtcCmip6.vue
@@ -16,6 +16,7 @@ const layers: MapLayer[] = [
     style: 'ardac_indicator_ftc_historical_era',
     legend: 'freeze_thaw_cycle',
     rasdamanConfiguration: { dim_model: 4, dim_scenario: 0 },
+    coastline: true,
   },
   {
     id: 'indicator_ftc_midcentury_era',
@@ -25,6 +26,7 @@ const layers: MapLayer[] = [
     style: 'ardac_indicator_ftc_midcentury_era',
     legend: 'freeze_thaw_cycle',
     rasdamanConfiguration: { dim_model: 4, dim_scenario: 4 },
+    coastline: true,
   },
   {
     id: 'indicator_ftc_latecentury_era',
@@ -34,6 +36,7 @@ const layers: MapLayer[] = [
     style: 'ardac_indicator_ftc_latecentury_era',
     legend: 'freeze_thaw_cycle',
     rasdamanConfiguration: { dim_model: 4, dim_scenario: 4 },
+    coastline: true,
   },
 ]
 

--- a/components/global/IndicatorRx1dayCmip6.vue
+++ b/components/global/IndicatorRx1dayCmip6.vue
@@ -16,6 +16,7 @@ const layers: MapLayer[] = [
     style: 'ardac_indicator_rx1day_historical_era',
     legend: 'rx1day',
     rasdamanConfiguration: { dim_model: 4, dim_scenario: 0 },
+    coastline: true,
   },
   {
     id: 'indicator_rx1day_midcentury_era',
@@ -25,6 +26,7 @@ const layers: MapLayer[] = [
     style: 'ardac_indicator_rx1day_midcentury_era',
     legend: 'rx1day',
     rasdamanConfiguration: { dim_model: 4, dim_scenario: 4 },
+    coastline: true,
   },
   {
     id: 'indicator_rx1day_latecentury_era',
@@ -34,6 +36,7 @@ const layers: MapLayer[] = [
     style: 'ardac_indicator_rx1day_latecentury_era',
     legend: 'rx1day',
     rasdamanConfiguration: { dim_model: 4, dim_scenario: 4 },
+    coastline: true,
   },
 ]
 

--- a/stores/map.ts
+++ b/stores/map.ts
@@ -134,7 +134,10 @@ export const useMapStore = defineStore('map', () => {
     // Remove existing active layer & coastline from map
     if (layerObjects[layerObj.mapId]) {
       maps[layerObj.mapId].removeLayer(layerObjects[layerObj.mapId])
-      if (maps[layerObj.mapId].hasLayer(coastlineLayer)) {
+      if (
+        coastlineLayer != undefined &&
+        maps[layerObj.mapId].hasLayer(coastlineLayer)
+      ) {
         maps[layerObj.mapId].removeLayer(coastlineLayer)
       }
     }

--- a/stores/map.ts
+++ b/stores/map.ts
@@ -13,9 +13,15 @@ var legendControls: { [index: string]: any } = {}
 // Legend items for each map, keyed like `maps` var above.
 var legendItems: { [index: string]: any } = {}
 
-import { tileLayer, latLng, latLngBounds, type MapOptions } from 'leaflet'
+import {
+  tileLayer,
+  latLng,
+  latLngBounds,
+  type TileLayer,
+  type MapOptions,
+} from 'leaflet'
 
-var coastlineLayer: MapLayerInstance
+var coastlineLayer: TileLayer.WMS
 
 function getBaseMapAndLayers(): MapOptions {
   const config = useRuntimeConfig()
@@ -125,10 +131,12 @@ export const useMapStore = defineStore('map', () => {
   function toggleLayer(layerObj: MapLayerInstance) {
     const config = useRuntimeConfig()
 
-    // Remove existing active layer from map
+    // Remove existing active layer & coastline from map
     if (layerObjects[layerObj.mapId]) {
       maps[layerObj.mapId].removeLayer(layerObjects[layerObj.mapId])
-      maps[layerObj.mapId].removeLayer(coastlineLayer)
+      if (maps[layerObj.mapId].hasLayer(coastlineLayer)) {
+        maps[layerObj.mapId].removeLayer(coastlineLayer)
+      }
     }
 
     // Build new layer configuration
@@ -151,13 +159,15 @@ export const useMapStore = defineStore('map', () => {
     layerObjects[layerObj.mapId] = tileLayer.wms(wmsUrl, layerConfiguration)
     maps[layerObj.mapId]?.addLayer(layerObjects[layerObj.mapId])
 
-    coastlineLayer = tileLayer.wms(config.public.geoserverUrl, {
-      transparent: true,
-      format: 'image/png',
-      version: '1.3.0',
-      layers: 'natural_earth:ne_10m_coastline',
-    })
-    maps[layerObj.mapId]?.addLayer(coastlineLayer)
+    if (layerObj.layer.coastline) {
+      coastlineLayer = tileLayer.wms(config.public.geoserverUrl, {
+        transparent: true,
+        format: 'image/png',
+        version: '1.3.0',
+        layers: 'natural_earth:ne_10m_coastline',
+      })
+      maps[layerObj.mapId]?.addLayer(coastlineLayer)
+    }
 
     activeLayers.value[layerObj.mapId] = layer
 

--- a/stores/map.ts
+++ b/stores/map.ts
@@ -15,6 +15,8 @@ var legendItems: { [index: string]: any } = {}
 
 import { tileLayer, latLng, latLngBounds, type MapOptions } from 'leaflet'
 
+var coastlineLayer: MapLayerInstance
+
 function getBaseMapAndLayers(): MapOptions {
   const config = useRuntimeConfig()
 
@@ -126,6 +128,7 @@ export const useMapStore = defineStore('map', () => {
     // Remove existing active layer from map
     if (layerObjects[layerObj.mapId]) {
       maps[layerObj.mapId].removeLayer(layerObjects[layerObj.mapId])
+      maps[layerObj.mapId].removeLayer(coastlineLayer)
     }
 
     // Build new layer configuration
@@ -148,7 +151,7 @@ export const useMapStore = defineStore('map', () => {
     layerObjects[layerObj.mapId] = tileLayer.wms(wmsUrl, layerConfiguration)
     maps[layerObj.mapId]?.addLayer(layerObjects[layerObj.mapId])
 
-    const coastlineLayer = tileLayer.wms(config.public.geoserverUrl, {
+    coastlineLayer = tileLayer.wms(config.public.geoserverUrl, {
       transparent: true,
       format: 'image/png',
       version: '1.3.0',

--- a/stores/map.ts
+++ b/stores/map.ts
@@ -148,6 +148,14 @@ export const useMapStore = defineStore('map', () => {
     layerObjects[layerObj.mapId] = tileLayer.wms(wmsUrl, layerConfiguration)
     maps[layerObj.mapId]?.addLayer(layerObjects[layerObj.mapId])
 
+    const coastlineLayer = tileLayer.wms(config.public.geoserverUrl, {
+      transparent: true,
+      format: 'image/png',
+      version: '1.3.0',
+      layers: 'natural_earth:ne_10m_coastline',
+    })
+    maps[layerObj.mapId]?.addLayer(coastlineLayer)
+
     activeLayers.value[layerObj.mapId] = layer
 
     addLegend(layerObj.mapId, layer.legend)

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -31,6 +31,7 @@ interface MapLayer {
   default?: boolean
   legend: string
   rasdamanConfiguration?: any
+  coastline?: boolean
 }
 
 interface MapLayerInstance {


### PR DESCRIPTION
Closes #63.

This PR adds the Natural Earth coastline layer to problematic maps (CMIP6 Freeze/Thaw Cycle and CMIP6 Maximum 1-day Precipitation) on top of the data layers. It's the same coastline layer we are already using in Northern Climate Reports that is hosted from GeoServer. This adds more context to otherwise-unintelligible CMIP6 indicator maps (see screenshot in #63).

To test & see the benefits of this change, view these CMIP6 indicator maps:

http://localhost:3000/item/indicator-ftc-cmip6
http://localhost:3000/item/indicator-rx1day-cmip6

Also verify that the coastline layer does not show up on the maps for other ARDAC items. This PR originally added the coastline to all maps in ARDAC Explorer, but I decided against this because it made the data layer harder to see on some maps, especially the Landfast Sea Ice map.