### PR TITLE
Add a progress bar when chart/table data is loading

### DIFF
--- a/components/Gimme.vue
+++ b/components/Gimme.vue
@@ -199,6 +199,7 @@ onUnmounted(() => {
       <p class="help" v-html="fieldMessage" />
     </div>
   </div>
+  <LoadIndicator />
 </template>
 
 <style lang="scss" scoped>

--- a/components/LoadIndicator.vue
+++ b/components/LoadIndicator.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+const placesStore = usePlacesStore()
+const dataStore = useDataStore()
+</script>
+
+<template>
+  <div v-if="placesStore.latLng && !dataStore.apiData && !dataStore.dataError">
+    <progress class="progress" />
+  </div>
+</template>


### PR DESCRIPTION
Closes #48.

This PR adds a progress bar below the place selector for all applicable ARDAC items (all ARDAC items that fetch data from the API for a chart or table).

To test, select a location to generate a chart for several different ARDAC items. Observe that:

- The progress bar is only visible while the app is actively trying to fetch data from the API.
- The progress bar disappears as soon as the chart or table loads.
- If there's an error (like an invalid location), the progress bar disappears as soon as the error is detected.