### PR TITLE
Hide chart inputs and download links when there is no data

### DIFF
--- a/components/PermafrostChartControls.vue
+++ b/components/PermafrostChartControls.vue
@@ -3,11 +3,14 @@ const props = defineProps<{
   defaultMonth?: string
 }>()
 
+const dataStore = useDataStore()
 const placesStore = usePlacesStore()
 const chartStore = useChartStore()
 
 const scenarioInput = defineModel({ default: 'RCP 8.5' })
+
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const apiData = computed<any[]>(() => dataStore.apiData)
 
 const chartLabels = computed<HydrologyChartLabels>(
   () => chartStore.labels as HydrologyChartLabels
@@ -25,7 +28,7 @@ watch([latLng, scenarioInput], async () => {
 </script>
 
 <template>
-  <div v-if="latLng && chartLabels">
+  <div v-if="latLng && chartLabels && apiData">
     <div class="parameter">
       <label for="scenario" class="label">Scenario:</label>
       <div class="select mb-5 mr-3">

--- a/components/global/PrecipitationFrequency.vue
+++ b/components/global/PrecipitationFrequency.vue
@@ -304,7 +304,7 @@ onUnmounted(() => {
         </div>
       </div>
       <div id="chart"></div>
-      <div v-if="latLng" class="my-6">
+      <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
           Download precipitation frequency data for {{ latLng.lat }},
           {{ latLng.lng }}


### PR DESCRIPTION
Closes #95.

This PR fixes a couple bugs:

- Hides the chart input (scenario dropdown) for all permafrost items when data is either still loading or not available
- Hides the download links for the Precipitation Frequency item when data is either still loading or not available

The easiest way to test this is to set your `SNAP_API_URL` environment variable to something bogus to simulate a data fetch error. For example:

```
export SNAP_API_URL=http://pizza.pizza:5000
```

Then, run the app and enter a location into the place selector for each of the following ARDAC items:

http://localhost:3000/item/permafrost-magt
http://localhost:3000/item/permafrost-base-top
http://localhost:3000/item/permafrost-talik
http://localhost:3000/item/precipitation-frequency

In each case, the data fetch will fail, and no chart inputs or download links should be displayed since there is no data available. I already double checked all other ARDAC items that use the place selector are bug-free, btw.