### PR TITLE
Disable invalid model/scenario combos and update CMIP6 model options

### DIFF
--- a/components/IndicatorsCmip6ChartControls.vue
+++ b/components/IndicatorsCmip6ChartControls.vue
@@ -7,8 +7,10 @@ const dataStore = useDataStore()
 const placesStore = usePlacesStore()
 const chartStore = useChartStore()
 
+const defaultScenario = 'ssp585'
+
 const modelInput = defineModel('model', { default: 'GFDL-ESM4' })
-const scenarioInput = defineModel('scenario', { default: 'ssp585' })
+const scenarioInput = defineModel('scenario', { default: defaultScenario })
 
 const apiData = computed<any[]>(() => dataStore.apiData)
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
@@ -19,6 +21,7 @@ const chartLabels = computed<IndicatorsCmip6ChartLabels>(
 
 chartStore.labels = {
   models: {
+    CESM2: 'CESM2',
     'CNRM-CM6-1-HR': 'CNRM-CM6-1-HR',
     'EC-Earth3-Veg': 'EC-Earth3-Veg',
     'GFDL-ESM4': 'GFDL-ESM4',
@@ -27,8 +30,6 @@ chartStore.labels = {
     'KACE-1-0-G': 'KACE-1-0-G',
     MIROC6: 'MIROC6',
     'MPI-ESM1-2-LR': 'MPI-ESM1-2-LR',
-    'NorESM2-MM': 'NorESM2-MM',
-    TaiESM1: 'TaiESM1',
   },
   scenarios: {
     ssp126: 'SSP1-2.6',
@@ -38,7 +39,19 @@ chartStore.labels = {
   },
 }
 
+// Some models do not have data for all scenarios. Use this function to react
+// accordingly by graying out scenario options or reverting back to the default
+// scenario if user accidentally lands on an invalid model/scenrio combination.
+const scenarioPresent = (value: string) => {
+  if (apiData.value) {
+    return apiData.value[value as any][modelInput.value] != null
+  }
+}
+
 watch([latLng, modelInput, scenarioInput], async () => {
+  if (!scenarioPresent(scenarioInput.value)) {
+    scenarioInput.value = defaultScenario
+  }
   chartStore.inputs = {
     model: modelInput.value,
     scenario: scenarioInput.value,
@@ -48,38 +61,33 @@ watch([latLng, modelInput, scenarioInput], async () => {
 
 <template>
   <div v-if="latLng && chartLabels && apiData">
-    <div class="columns is-multiline">
-      <div class="column is-6">
-        <div class="parameter">
-          <label for="model" class="label">Model:</label>
-          <div class="select">
-            <select v-model="modelInput">
-              <option
-                v-for="(label, value) in chartLabels.models"
-                :key="value"
-                :value="value"
-              >
-                {{ label }}
-              </option>
-            </select>
-          </div>
-        </div>
+    <div class="parameter">
+      <label for="model" class="label">Model:</label>
+      <div class="select mb-5 mr-3">
+        <select v-model="modelInput">
+          <option
+            v-for="(label, value) in chartLabels.models"
+            :key="value"
+            :value="value"
+          >
+            {{ label }}
+          </option>
+        </select>
       </div>
-      <div class="column is-6">
-        <div class="parameter">
-          <label for="scenario" class="label">Scenario:</label>
-          <div class="select">
-            <select v-model="scenarioInput">
-              <option
-                v-for="(label, value) in chartLabels.scenarios"
-                :key="value"
-                :value="value"
-              >
-                {{ label }}
-              </option>
-            </select>
-          </div>
-        </div>
+    </div>
+    <div class="parameter">
+      <label for="scenario" class="label">Scenario:</label>
+      <div class="select">
+        <select v-model="scenarioInput">
+          <option
+            v-for="(label, value) in chartLabels.scenarios"
+            :key="value"
+            :value="value"
+            :disabled="!scenarioPresent(value)"
+          >
+            {{ label }}
+          </option>
+        </select>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Closes #93.

Not all scenarios (SSPs) are available for every model from our CMIP6 Indicators Data API endpoint. Invalid model + SSP combinations are set to `null` in the API output. This PR prevents users from accidentally selecting an invalid model + SSP combination from the CMIP6 Indicator chart dropdown menus by graying out SSPs that are unavailable for the selected model.

If a user first selects an SSP, then selects a model that does not support that SSP, I've added some code to revert back to the default SSP (SSP5-8.5) since this scenario is present for all models.

I've also updated the available model choices to reflect our current API output since these seem to have changed somewhere along the way.

To test, enter a location to load a chart for any of the CMIP6 Indicators ARDAC items:

http://arcticdatascience.org/item/indicator-ftc-cmip6
http://arcticdatascience.org/item/indicator-su-cmip6
http://arcticdatascience.org/item/indicator-dw-cmip6
http://arcticdatascience.org/item/indicator-rx1day-cmip6

Experiment with selecting various models from the "Model" dropdown menu and observe that, depending on what model you chose, some SSP options are grayed out in the "Scenario" dropdown. A new chart should load no matter what model + SSP combo you select.