### PR TITLE
Change default month for hydrology charts from June to March, and fix ice water equivalent map legend

### DIFF
--- a/components/HydrologyChartControls.vue
+++ b/components/HydrologyChartControls.vue
@@ -8,7 +8,7 @@ const placesStore = usePlacesStore()
 const chartStore = useChartStore()
 
 const scenarioInput = defineModel('scenario', { default: 'rcp85' })
-const monthInput = defineModel('month', { default: 'jun' })
+const monthInput = defineModel('month', { default: 'mar' })
 
 if (props.defaultMonth) {
   monthInput.value = props.defaultMonth

--- a/components/global/HydrologyIswe.vue
+++ b/components/global/HydrologyIswe.vue
@@ -66,7 +66,7 @@ const layers: MapLayer[] = [
 
 const legend: Record<string, LegendItem[]> = {
   iwe: [
-    { color: '#9ecae1', label: '&ge;0m, &lt;200m' },
+    { color: '#9ecae1', label: '&gt;0m, &lt;200m' },
     { color: '#6baed6', label: '&ge;200m, &lt;400m' },
     { color: '#4292c6', label: '&ge;400m, &lt;600m' },
     { color: '#2171b5', label: '&ge;600m, &lt;800m' },


### PR DESCRIPTION
Closes #68.

This PR mostly just changes the default month for all hydrology charts from June to March. Without this change, snow water equivalent charts were almost always all-zero on initial load.

To see the change, load the app and go to this URL:

http://localhost:3000/item/hydrology-iswe

Enter Fairbanks into the place selector and notice that the snow water equivalent chart loads with a bunch of non-zero values, whereas if you select the month of June the chart is all-zero.

You'll also notice that the ice water equivalent chart is all-zero for Fairbanks regardless of what month you choose. This is because ice water equivalent is zero for Fairbanks (and most locations) for all months. This agrees with the ice water equivalent maps on the same page. Incidentally, I've also fixed the first color threshold of the ice water equivalent map legend from "≥0" to ">0" since our ice water equivalent Rasdaman style is configured to render 0 as transparent.

To see a non-zero ice water equivalent chart, enter Valdez into the place selector. The data on the ice water equivalent chart is non-zero but looks unusual, I've captured this in issue #107.