### PR TITLE
Add beta notification banner

### DIFF
--- a/components/BetaNotice.vue
+++ b/components/BetaNotice.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
-    <div v-if="store.showBetaNotice" class="notification is-warning my-5">
+    <div v-if="store.showBetaNotice" class="notification is-warning is-size-4 my-5">
       <button class="delete" @click="hideNotification"></button>
-      Thanks for checking out this tool! This is a public beta, which means that
+      Thanks for trying out this site! This is a <strong>public pre-release</strong>, which means that
       we&rsquo;re still gathering feedback, testing data outputs and fixing
       bugs. Please contact
       <a href="mailto:uaf-snap-data-tools@alaska.edu"
@@ -22,7 +22,6 @@ const hideNotification = () => {
 
 <style lang="scss" scoped>
 .notification {
-  max-width: 800px;
   margin: 0 auto;
 }
 </style>

--- a/components/BetaNotice.vue
+++ b/components/BetaNotice.vue
@@ -1,0 +1,28 @@
+<template>
+  <div>
+    <div v-if="store.showBetaNotice" class="notification is-warning my-5">
+      <button class="delete" @click="hideNotification"></button>
+      Thanks for checking out this tool! This is a public beta, which means that
+      we&rsquo;re still gathering feedback, testing data outputs and fixing
+      bugs. Please contact
+      <a href="mailto:uaf-snap-data-tools@alaska.edu"
+        >uaf-snap-data-tools@alaska.edu</a
+      >
+      if you encounter any bugs or would like to provide feedback.
+    </div>
+  </div>
+</template>
+
+<script setup>
+const store = useStore()
+const hideNotification = () => {
+  store.showBetaNotice = false
+}
+</script>
+
+<style lang="scss" scoped>
+.notification {
+  max-width: 800px;
+  margin: 0 auto;
+}
+</style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -4,6 +4,7 @@
   <HeaderBanner />
   <Navbar />
   <Edition />
+  <BetaNotice />
   <div class="container is-fullhd">
     <Header />
     <Tagbar />

--- a/layouts/home.vue
+++ b/layouts/home.vue
@@ -4,6 +4,7 @@
   <HeaderBanner />
   <Navbar />
   <Edition />
+  <BetaNotice />
   <div class="container is-fullhd">
     <Header />
     <section class="section">

--- a/stores/store.ts
+++ b/stores/store.ts
@@ -10,6 +10,7 @@ export const useStore = defineStore('store', () => {
   const totalItemCount = ref(items.length)
   const filteredItems: Ref<Item[]> = ref(items)
   const searchActive = ref(false)
+  const showBetaNotice = ref(true)
 
   // Sort items with a priority field above items without a priority field.
   // For items with a priority field, lower numbers sort higher.
@@ -52,5 +53,6 @@ export const useStore = defineStore('store', () => {
     sortedFilteredItems,
     itemBySlug,
     itemHasComponent,
+    showBetaNotice,
   }
 })


### PR DESCRIPTION
Closes #49.

This PR adds a beta notification banner near the top of the webapp, across all pages. The banner can be closed and this setting persists in the Pinia store until the app is reloaded.

I experimented with the placement of this banner and ultimately it seems to fit best (aesthetically and thematically) right below the "edition" component.

To test, load the app and:

- Visit a few different pages to confirm that the beta banner shows up everywhere
- Close the banner
- Confirm that the banner no longer appears on any page until you reload the app