### PR TITLE
Choose chart mean rounding precision based on value range

### DIFF
--- a/components/DegreeDaysChart.vue
+++ b/components/DegreeDaysChart.vue
@@ -5,6 +5,7 @@ const props = defineProps<{
 }>()
 
 import type { Data } from 'plotly.js-dist-min'
+import { precisionMean } from '~/utils/math'
 
 const { $Plotly, $_ } = useNuxtApp()
 const dataStore = useDataStore()
@@ -50,7 +51,7 @@ const getPlotValues = (minYear: number, maxYear: number, model: string) => {
   let minOffsets: number[] = []
 
   decades.forEach(decade => {
-    let mean = Math.round($_.mean(decadeBuckets[decade]))
+    let mean = precisionMean(decadeBuckets[decade])
     let min = $_.min(decadeBuckets[decade])
     let max = $_.max(decadeBuckets[decade])
 

--- a/components/IndicatorsCmip6Chart.vue
+++ b/components/IndicatorsCmip6Chart.vue
@@ -6,6 +6,7 @@ const props = defineProps<{
 }>()
 
 import type { Data } from 'plotly.js-dist-min'
+import { precisionMean } from '~/utils/math'
 
 const { $Plotly, $_ } = useNuxtApp()
 const dataStore = useDataStore()
@@ -63,7 +64,7 @@ const getPlotValues = (params: any) => {
   let minOffsets: number[] = []
 
   decades.forEach(decade => {
-    let mean = $_.mean(decadeBuckets[decade].map(Number))
+    let mean = precisionMean(decadeBuckets[decade].map(Number))
     let min = $_.min(decadeBuckets[decade].map(Number))
     let max = $_.max(decadeBuckets[decade].map(Number))
 

--- a/components/PermafrostChart.vue
+++ b/components/PermafrostChart.vue
@@ -7,6 +7,7 @@ const props = defineProps<{
 }>()
 
 import type { Data } from 'plotly.js-dist-min'
+import { precisionMean } from '~/utils/math'
 
 const { $Plotly, $_ } = useNuxtApp()
 const dataStore = useDataStore()
@@ -55,7 +56,7 @@ const getPlotValues = (minYear: number, maxYear: number, model: string) => {
   let minOffsets: number[] = []
 
   decades.forEach(decade => {
-    let mean = Math.round($_.mean(decadeBuckets[decade]))
+    let mean = precisionMean(decadeBuckets[decade])
     let min = $_.min(decadeBuckets[decade])
     let max = $_.max(decadeBuckets[decade])
 

--- a/components/global/WetDaysPerYear.vue
+++ b/components/global/WetDaysPerYear.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import type { Data } from 'plotly.js-dist-min'
+import { precisionMean } from '~/utils/math'
 import { useMapStore } from '~/stores/map'
 
 const { $Plotly, $_ } = useNuxtApp()
@@ -89,7 +90,7 @@ const getPlotValues = (minYear: number, maxYear: number, model: string) => {
   let minOffsets: number[] = []
 
   decades.forEach(decade => {
-    let mean = Math.round($_.mean(decadeBuckets[decade]))
+    let mean = precisionMean(decadeBuckets[decade])
     let min = $_.min(decadeBuckets[decade])
     let max = $_.max(decadeBuckets[decade])
 

--- a/utils/math.js
+++ b/utils/math.js
@@ -1,0 +1,8 @@
+const { $_ } = useNuxtApp()
+
+// Calculate mean and choose rounding precision based on the range of values.
+export const precisionMean = values => {
+  let diff = $_.max(values) - $_.min(values)
+  let mean = $_.mean(values)
+  return diff < 10 ? $_.round(mean, 1) : $_.round(mean)
+}


### PR DESCRIPTION
Closes #65.

This PR addresses overaggressive rounding in charts where we calculate the decadal mean from yearly values client-side. Look at the hovertext in the screenshot below to see what I mean:

![image](https://github.com/ua-snap/ardac-explorer/assets/2566292/f028e2f6-d37b-4c61-977a-876ee3c64152)

Since the mean is rounded to a whole number, `0`, it ends up being larger than the max number. And because of this, the plot marker is placed above/outside of the error bars.

To solve this, I've created a new utility function, `precisionMean`, that calculates the difference between the min/max values and rounds the mean to 1 decimal of precision if the difference is less than 10. If the difference is greater than (or equal to) 10, it continues to round to a whole number.

Here's a screenshot of the same chart using the new `precisionMean` function:

![image](https://github.com/ua-snap/ardac-explorer/assets/2566292/112d134c-a971-4c36-bf4b-eda43b0c51a5)

To test, run the webapp against Zeus:

```
export RASDAMAN_URL=https://zeus.snap.uaf.edu/rasdaman/ows
export SNAP_API_URL=http://development.earthmaps.io
npm run dev
```

Then look at the charts for a few of the affected ARDAC items below and make sure the mean rounding in the hovertext is what you'd expect:


http://localhost:3000/item/dd-below-65
http://localhost:3000/item/dd-below-0
http://localhost:3000/item/thawing-index
http://localhost:3000/item/freezing-index
http://localhost:3000/item/wet-days-per-year
http://localhost:3000/item/permafrost-magt
http://localhost:3000/item/permafrost-base-top
http://localhost:3000/item/permafrost-talik
http://localhost:3000/item/indicator-ftc-cmip6
http://localhost:3000/item/indicator-su-cmip6
http://localhost:3000/item/indicator-dw-cmip6
http://localhost:3000/item/indicator-rx1day-cmip6