### PR TITLE
Add Umami analytics

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -58,6 +58,16 @@ export default defineNuxtConfig({
           children: noscriptHtml,
         },
       ],
+      script: [
+        {
+          src: 'https://umami.snap.uaf.edu/script.js',
+          'data-website-id': '29d337b9-9cf3-4962-a319-f4944161b550',
+          'data-do-not-track': 'true',
+          'data-domains': 'arcticdatascience.org',
+          async: 'true',
+          defer: 'true',
+        },
+      ],
     },
   },
 })


### PR DESCRIPTION
Closes #55.

This PR adds Umami analytics to the webapp.

To test:

- Boot up your local umami Vagrant VM with `vagrant up`. If you no longer have this handy, follow the setup instructions described here https://github.com/ua-snap/nccwsc-projects/pull/154.
- Visit your local Umami's dashboard at http://localhost:9999/
- Authenticate through local Umami's web interface if necessary, using the Umami web interface credentials in Bitwarden
- Go to the "Settings" page and create a new website for "ARDAC Explorer" using its real domain (doesn't really matter)
- Modify the webapp code in the `add_umami` branch
  - Change the Umami `src` to `http://localhost:9999/script.js`
  - Replace the Umami website ID with the one that was generated when you created the "ARDAC Explorer" website
  - Comment out the `data-domains` line to disable domain enforcement for testing
- Run the webapp and visit some pages
- Verify that the traffic is showing up in the Umami web interface for the "ARDAC Explorer" website

The "ARDAC Explorer" website has already been created on the production Umami instance, so if everything looks good through local testing, it should work just as well on the production instance.