### PR TITLE
Add six new CMIP6 data x-ray items

### DIFF
--- a/assets/items.ts
+++ b/assets/items.ts
@@ -305,7 +305,7 @@ export default [
     slug: 'temperature-cmip6',
     title: 'Temperature, CMIP6',
     blurb:
-      'Monthly model outputs for mean near-surface air temperature, min/max near-surface air temperature, and mean surface temperature',
+      'Monthly model outputs for min/mean/max near-surface air temperature',
     tags: ['Temperature', 'CMIP6'],
   },
   {
@@ -350,19 +350,20 @@ export default [
     slug: 'wind-cmip6',
     title: 'Wind, CMIP6',
     blurb:
-      'Monthly model outputs for mean near-surface wind speed, mean near-surface eastward wind speed, and mean near-surface northward wind speed',
+      'Monthly model outputs for mean near-surface wind speed, near-surface eastward wind speed, and near-surface northward wind speed',
     tags: ['Wind', 'CMIP6'],
   },
   {
     slug: 'oceanography-cmip6',
     title: 'Oceanography, CMIP6',
-    blurb: 'Sea level pressure, surface temperature and mixed layer thickness',
+    blurb:
+      'Monthly model outputs for mean sea level pressure and surface temperature',
     tags: ['Oceanography', 'CMIP6'],
   },
   {
     slug: 'precipitation-cmip6',
     title: 'Precipitation, CMIP6',
-    blurb: 'Monthly total precipitation model outputs',
+    blurb: 'Monthly model outputs for total precipitation',
     tags: ['Precipitation', 'CMIP6'],
   },
   {
@@ -373,29 +374,17 @@ export default [
     tags: ['Climate', 'CMIP6'],
   },
   {
-    slug: 'sea-level-pressure-cmip6',
-    title: 'Sea Level Pressure, CMIP6',
-    blurb: 'Monthly mean sea level pressure model outputs',
-    tags: ['Climate', 'CMIP6'],
+    slug: 'solar-radiation-cloud-cover-cmip6',
+    title: 'Solar Radiation & Cloud Cover, CMIP6',
+    blurb:
+      'Monthly model outputs for mean downwelling shortwave and longwave fluxes, surface upward sensible and latent heat fluxes, and cloud area fraction',
+    tags: ['Solar Radiation', 'CMIP6'],
   },
   {
     slug: 'sea-ice-cmip6',
     title: 'Sea Ice Concentration, CMIP6',
     blurb: 'Sea ice fraction',
     tags: ['Sea Ice', 'CMIP6', 'Cryosphere'],
-  },
-  {
-    slug: 'hydrology-cmip6',
-    title: 'Hydrology, CMIP6',
-    blurb: 'Evapotranspiration, total runoff and soil moisture',
-    tags: ['Hydrology', 'CMIP6'],
-  },
-  {
-    slug: 'solar-radiation-cloud-cover-cmip6',
-    title: 'Solar Radiation & Cloud Cover, CMIP6',
-    blurb:
-      'Monthly model outputs for mean cloud area fraction, mean downwelling shortwave and longwave flux, and mean surface upward sensible and latent heat fluxes',
-    tags: ['Solar Radiation', 'CMIP6'],
   },
   {
     slug: 'snow-cmip6',

--- a/assets/items.ts
+++ b/assets/items.ts
@@ -303,8 +303,9 @@ export default [
   },
   {
     slug: 'temperature-cmip6',
-    title: 'Temperature & Humidity, CMIP6',
-    blurb: 'Coarse-resolution temperature model outputs, CMIP6',
+    title: 'Temperature, CMIP6',
+    blurb:
+      'Monthly model outputs for mean near-surface air temperature, min/max near-surface air temperature, and mean surface temperature',
     tags: ['Temperature', 'CMIP6'],
   },
   {
@@ -348,7 +349,8 @@ export default [
   {
     slug: 'wind-cmip6',
     title: 'Wind, CMIP6',
-    blurb: 'Near-surface and surface, including maximums and wind component',
+    blurb:
+      'Monthly model outputs for mean near-surface wind speed, mean near-surface eastward wind speed, and mean near-surface northward wind speed',
     tags: ['Wind', 'CMIP6'],
   },
   {
@@ -360,8 +362,21 @@ export default [
   {
     slug: 'precipitation-cmip6',
     title: 'Precipitation, CMIP6',
-    blurb: 'Total precipitation, daily and monthly',
+    blurb: 'Monthly total precipitation model outputs',
     tags: ['Precipitation', 'CMIP6'],
+  },
+  {
+    slug: 'evaporation-cmip6',
+    title: 'Evaporation, CMIP6',
+    blurb:
+      'Monthly model outputs for total evaporation, including sublimation and transpiration',
+    tags: ['Climate', 'CMIP6'],
+  },
+  {
+    slug: 'sea-level-pressure-cmip6',
+    title: 'Sea Level Pressure, CMIP6',
+    blurb: 'Monthly mean sea level pressure model outputs',
+    tags: ['Climate', 'CMIP6'],
   },
   {
     slug: 'sea-ice-cmip6',
@@ -378,7 +393,8 @@ export default [
   {
     slug: 'solar-radiation-cloud-cover-cmip6',
     title: 'Solar Radiation & Cloud Cover, CMIP6',
-    blurb: 'Cloud fraction, shortwave and longwave and heat fluxes',
+    blurb:
+      'Monthly model outputs for mean cloud area fraction, mean downwelling shortwave and longwave flux, and mean surface upward sensible and latent heat fluxes',
     tags: ['Solar Radiation', 'CMIP6'],
   },
   {

--- a/components/Cmip6MonthlyChart.vue
+++ b/components/Cmip6MonthlyChart.vue
@@ -1,0 +1,183 @@
+<script lang="ts" setup>
+const props = defineProps<{
+  label: string
+  units?: string
+  dataKey: string
+}>()
+
+import type { Data } from 'plotly.js-dist-min'
+
+const { $Plotly, $_ } = useNuxtApp()
+const dataStore = useDataStore()
+const placesStore = usePlacesStore()
+const chartStore = useChartStore()
+
+const apiData = computed<any[]>(() => dataStore.apiData)
+const latLng = computed<LatLngValue>(() => placesStore.latLng)
+
+const chartLabels = computed<Cmip6MonthlyChartLabelsObj>(
+  () => chartStore.labels as Cmip6MonthlyChartLabelsObj
+)
+const chartInputs = computed<Cmip6MonthlyChartInputsObj>(
+  () => chartStore.inputs as Cmip6MonthlyChartInputsObj
+)
+
+const chartId = computed<string>(() => props.dataKey + '-chart')
+const validChart = ref(true)
+
+const buildChart = () => {
+  if (apiData.value && chartLabels.value && chartInputs.value) {
+    let traces: Data[] = []
+    let chartData = dataStore.apiData
+    let projectedStartYear = 2015
+
+    // Pad the historical/projected with nulls as needed to line up properly
+    // with the chart x-axis ticks.
+    let traceConfig = [
+      {
+        label: 'Modeled Baseline',
+        years: $_.range(1950, projectedStartYear).concat(
+          Array(2100 - projectedStartYear + 1).fill(null)
+        ),
+        symbol: 'circle',
+      },
+      {
+        label: 'Projected',
+        years: $_.range(projectedStartYear, 2101).concat(
+          Array(2100 - projectedStartYear + 1).fill(null)
+        ),
+        symbol: 'square',
+      },
+    ]
+
+    let model = chartInputs.value!.model
+    let month = chartInputs.value!.month
+    let scenario: string
+    let allChartValues: Array<number | null> = []
+
+    traceConfig.forEach(config => {
+      let values: Array<number | null> = []
+      config.years.forEach((year: number) => {
+        let yearMonth = year + '-' + month
+        if (year < projectedStartYear) {
+          scenario = 'historical'
+        } else {
+          scenario = chartInputs.value!.scenario
+        }
+
+        if (year == null) {
+          values.push(null)
+          return
+        }
+
+        if (!chartData[model][scenario]) {
+          values.push(null)
+          return
+        }
+
+        let yearMonthData = chartData[model][scenario][yearMonth]
+        let value = yearMonthData[props.dataKey]
+        values.push(value)
+      })
+
+      traces.push({
+        x: config.years,
+        y: values,
+        mode: 'markers',
+        type: 'scatter',
+        name: config.label,
+        marker: {
+          symbol: config.symbol,
+        },
+      })
+
+      allChartValues = allChartValues.concat(values)
+    })
+
+    // If trace values are nothing but a mixture of nulls and undefineds,
+    // then this is not a valid chart. Hide the chart.
+    if (allChartValues.every(value => value == null || value === undefined)) {
+      validChart.value = false
+      return
+    }
+
+    let yAxisLabel = props.label
+    if (props.units) {
+      yAxisLabel += ' (' + props.units + ')'
+    }
+
+    $Plotly.newPlot(
+      chartId.value,
+      traces,
+      {
+        title: {
+          text:
+            props.label +
+            ' for ' +
+            placesStore.latLng?.lat +
+            ', ' +
+            placesStore.latLng?.lng +
+            '<br />' +
+            'Model: ' +
+            chartLabels.value.models[chartInputs.value.model] +
+            ', Scenario: ' +
+            chartLabels.value.scenarios[chartInputs.value.scenario] +
+            ', Month: ' +
+            chartLabels.value.months[chartInputs.value.month],
+          font: {
+            size: 24,
+          },
+        },
+        xaxis: {
+          tickangle: 45,
+        },
+        yaxis: {
+          title: {
+            text: yAxisLabel,
+            font: {
+              size: 18,
+            },
+          },
+        },
+      },
+      {
+        responsive: true, // changes the height / width dynamically for charts
+        displayModeBar: true, // always show the camera icon
+        displaylogo: false,
+        modeBarButtonsToRemove: [
+          'zoom2d',
+          'pan2d',
+          'select2d',
+          'lasso2d',
+          'zoomIn2d',
+          'zoomOut2d',
+          'autoScale2d',
+          'resetScale2d',
+        ],
+      }
+    )
+  }
+}
+
+watch([apiData, chartLabels, chartInputs], async () => {
+  validChart.value = true
+  $Plotly.purge(chartId.value)
+  if (apiData.value) {
+    buildChart()
+  }
+})
+
+watch(latLng, async () => {
+  $Plotly.purge(chartId.value)
+})
+
+onUnmounted(() => {
+  dataStore.apiData = null
+})
+</script>
+
+<template>
+  <div :id="chartId" v-if="validChart"></div>
+</template>
+
+<style lang="scss" scoped></style>

--- a/components/Cmip6MonthlyChartControls.vue
+++ b/components/Cmip6MonthlyChartControls.vue
@@ -1,0 +1,153 @@
+<script lang="ts" setup>
+const props = defineProps<{
+  defaultModel?: string
+  defaultMonth?: string
+  datasetKeys?: string[]
+}>()
+
+const dataStore = useDataStore()
+const placesStore = usePlacesStore()
+const chartStore = useChartStore()
+
+const defaultScenario = 'ssp585'
+
+const modelInput = defineModel('model', { default: 'EC-Earth3-Veg' })
+const scenarioInput = defineModel('scenario', { default: defaultScenario })
+const monthInput = defineModel('month', { default: '08' })
+
+if (props.defaultModel) {
+  modelInput.value = props.defaultModel
+}
+
+if (props.defaultMonth) {
+  monthInput.value = props.defaultMonth
+}
+
+const apiData = computed<any[]>(() => dataStore.apiData)
+const latLng = computed<LatLngValue>(() => placesStore.latLng)
+
+const chartLabels = computed<Cmip6MonthlyChartLabels>(
+  () => chartStore.labels as Cmip6MonthlyChartLabels
+)
+
+chartStore.labels = {
+  models: {
+    CESM2: 'CESM2',
+    'CNRM-CM6-1-HR': 'CNRM-CM6-1-HR',
+    'EC-Earth3-Veg': 'EC-Earth3-Veg',
+    'GFDL-ESM4': 'GFDL-ESM4',
+    'HadGEM3-GC31-LL': 'HadGEM3-GC31-LL',
+    'HadGEM3-GC31-MM': 'HadGEM3-GC31-MM',
+    'KACE-1-0-G': 'KACE-1-0-G',
+    MIROC6: 'MIROC6',
+    'MPI-ESM1-2-HR': 'MPI-ESM1-2-HR',
+    'MRI-ESM2-0': 'MRI-ESM2-0',
+    'NorESM2-MM': 'NorESM2-MM',
+    TaiESM1: 'TaiESM1',
+  },
+  scenarios: {
+    ssp126: 'SSP1-2.6',
+    ssp245: 'SSP2-4.5',
+    ssp370: 'SSP3-7.0',
+    ssp585: 'SSP5-8.5',
+  },
+  months: {
+    '01': 'January',
+    '02': 'February',
+    '03': 'March',
+    '04': 'April',
+    '05': 'May',
+    '06': 'June',
+    '07': 'July',
+    '08': 'August',
+    '09': 'September',
+    '10': 'October',
+    '11': 'November',
+    '12': 'December',
+  },
+}
+
+// Some models do not have data for all scenarios. Use this function to react
+// accordingly by graying out scenario options or reverting back to the default
+// scenario if user accidentally lands on an invalid model/scenrio combination.
+const scenarioPresent = (value: string) => {
+  if (apiData.value) {
+    return apiData.value[modelInput.value as any][value] != null
+  }
+}
+
+watch([latLng, modelInput, scenarioInput, monthInput], async () => {
+  if (!scenarioPresent(scenarioInput.value)) {
+    scenarioInput.value = defaultScenario
+  }
+  chartStore.inputs = {
+    model: modelInput.value,
+    scenario: scenarioInput.value,
+    month: monthInput.value,
+  }
+})
+
+watch(latLng, async () => {
+  dataStore.apiData = null
+  let params = ''
+  if (props.datasetKeys) {
+    params = '?vars=' + props.datasetKeys.join(',')
+  }
+  dataStore.fetchData('cmip6Monthly', params)
+})
+</script>
+
+<template>
+  <div v-if="latLng && chartLabels && apiData">
+    <div class="parameter">
+      <label for="scenario" class="label">Model:</label>
+      <div class="select mb-5 mr-3">
+        <select id="scenario" v-model="modelInput">
+          <option
+            v-for="model in Object.keys(chartLabels.models)"
+            :value="model"
+          >
+            {{ chartLabels.models[model] }}
+          </option>
+        </select>
+      </div>
+    </div>
+    <div class="parameter mb-5">
+      <label for="scenario" class="label">Scenario:</label>
+      <div class="select mb-5 mr-3">
+        <select id="scenario" v-model="scenarioInput">
+          <option
+            v-for="(label, value) in chartLabels.scenarios"
+            :key="value"
+            :value="value"
+            :disabled="!scenarioPresent(value)"
+          >
+            {{ label }}
+          </option>
+        </select>
+      </div>
+    </div>
+    <div class="parameter mb-5">
+      <label for="month" class="label">Month:</label>
+      <div class="select">
+        <select id="month" v-model="monthInput">
+          <option
+            v-for="month in Object.keys(chartLabels.months).sort()"
+            :value="month"
+          >
+            {{ chartLabels.months[month] }}
+          </option>
+        </select>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.parameter {
+  display: inline-block;
+  select {
+    background-color: $white-lighter;
+  }
+}
+</style>

--- a/components/Map.vue
+++ b/components/Map.vue
@@ -39,5 +39,10 @@ onUnmounted(() => {
     width: 20px;
     height: 20px;
   }
+  sup {
+    position: relative;
+    top: -0.2em;
+    font-size: 0.8em;
+  }
 }
 </style>

--- a/components/global/EvaporationCmip6.vue
+++ b/components/global/EvaporationCmip6.vue
@@ -1,0 +1,231 @@
+<script lang="ts" setup>
+const placesStore = usePlacesStore()
+const mapStore = useMapStore()
+const dataStore = useDataStore()
+const runtimeConfig = useRuntimeConfig()
+
+const apiData = computed<any[]>(() => dataStore.apiData)
+const latLng = computed<LatLngValue>(() => placesStore.latLng)
+
+const layers: MapLayer[] = [
+  {
+    id: 'evspsbl_cmip6_1950',
+    title: 'August 1950, EC-Earth3-Veg',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_evspsbl',
+    legend: 'evspsbl',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 0,
+      time: '1950-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'evspsbl_cmip6_1975',
+    title: 'August 1975, EC-Earth3-Veg',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_evspsbl',
+    legend: 'evspsbl',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 0,
+      time: '1975-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'evspsbl_cmip6_2000',
+    title: 'August 2000, EC-Earth3-Veg',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_evspsbl',
+    legend: 'evspsbl',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 0,
+      time: '2000-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'evspsbl_cmip6_2025',
+    title: 'August 2025, EC-Earth3-Veg, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_evspsbl',
+    legend: 'evspsbl',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 4,
+      time: '2025-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'evspsbl_cmip6_2050',
+    title: 'August 2050, EC-Earth3-Veg, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_evspsbl',
+    legend: 'evspsbl',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 4,
+      time: '2050-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'evspsbl_cmip6_2075',
+    title: 'August 2075, EC-Earth3-Veg, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_evspsbl',
+    legend: 'evspsbl',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 4,
+      time: '2075-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'evspsbl_cmip6_2100',
+    title: 'August 2100, EC-Earth3-Veg, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_evspsbl',
+    legend: 'evspsbl',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 4,
+      time: '2100-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+]
+
+const legend: Record<string, LegendItem[]> = {
+  evspsbl: [
+    { color: '#006837', label: '&lt;0µ kg/m<sup>2</sup>/s' },
+    {
+      color: '#31a354',
+      label: '&ge;0µ kg/m<sup>2</sup>/s, &lt;10µ kg/m<sup>2</sup>/s',
+    },
+    {
+      color: '#78c679',
+      label: '&ge;10µ kg/m<sup>2</sup>/s, &lt;20µ kg/m<sup>2</sup>/s',
+    },
+    {
+      color: '#addd8e',
+      label: '&ge;20µ kg/m<sup>2</sup>/s, &lt;30µ kg/m<sup>2</sup>/s',
+    },
+    {
+      color: '#d9f0a3',
+      label: '&ge;30µ kg/m<sup>2</sup>/s, &lt;40µ kg/m<sup>2</sup>/s',
+    },
+    { color: '#ffffcc', label: '&ge;40µ kg/m<sup>2</sup>/s' },
+  ],
+}
+
+const mapId = 'evspsbl'
+mapStore.setLegendItems(mapId, legend)
+
+onUnmounted(() => {
+  dataStore.apiData = null
+})
+</script>
+
+<template>
+  <section class="section">
+    <div class="content is-size-5">
+      <h3 class="title is-3">Evaporation, CMIP6</h3>
+      <p class="mb-6">
+        The map below shows modeled total evaporation for the month of August
+        using the EC-Earth3-Veg model at 25-year intervals from 1950–2000.
+        Intervals from 2025–2100 are based on the SSP5-8.5 emissions scenario.
+      </p>
+
+      <MapBlock :mapId="mapId" class="mb-6">
+        <template v-slot:layers>
+          <MapLayer :mapId="mapId" :layer="layers[0]" default>
+            <template v-slot:title>{{ layers[0].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[1]">
+            <template v-slot:title>{{ layers[1].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[2]">
+            <template v-slot:title>{{ layers[2].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[3]">
+            <template v-slot:title>{{ layers[3].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[4]">
+            <template v-slot:title>{{ layers[4].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[5]">
+            <template v-slot:title>{{ layers[5].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[6]">
+            <template v-slot:title>{{ layers[6].title }}</template>
+          </MapLayer>
+        </template>
+      </MapBlock>
+
+      <p>
+        Enter a location below to see a chart of the total evaporation for a
+        point location using the selected model, emissions scenario, and month.
+        After entering a location, links will be provided where you can download
+        the data that is used to populate the chart.
+      </p>
+
+      <Gimme />
+      <Cmip6MonthlyChartControls defaultMonth="08" :datasetKeys="['evspsbl']" />
+      <Cmip6MonthlyChart
+        label="Evaporation"
+        units="kg/m<sup>2</sup>/s"
+        dataKey="evspsbl"
+      />
+
+      <div v-if="latLng && apiData" class="my-6">
+        <h4 class="title is-4">
+          Download CMIP6 evaporation data for {{ latLng.lat }},
+          {{ latLng.lng }}
+        </h4>
+        <ul>
+          <li>
+            <a
+              :href="
+                runtimeConfig.public.apiUrl +
+                '/cmip6/point/' +
+                latLng.lat +
+                '/' +
+                latLng.lng +
+                '?vars=evspsbl&format=csv'
+              "
+              >Download as CSV</a
+            >
+          </li>
+          <li>
+            <a
+              :href="
+                runtimeConfig.public.apiUrl +
+                '/cmip6/point/' +
+                latLng.lat +
+                '/' +
+                latLng.lng +
+                'vars=evspsbl'
+              "
+              >Download as JSON</a
+            >
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style lang="scss" scoped></style>

--- a/components/global/EvaporationCmip6.vue
+++ b/components/global/EvaporationCmip6.vue
@@ -217,7 +217,7 @@ onUnmounted(() => {
                 latLng.lat +
                 '/' +
                 latLng.lng +
-                'vars=evspsbl'
+                '?vars=evspsbl'
               "
               >Download as JSON</a
             >

--- a/components/global/OceanographyCmip6.vue
+++ b/components/global/OceanographyCmip6.vue
@@ -140,7 +140,12 @@ onUnmounted(() => {
         defaultMonth="08"
         :datasetKeys="['psl', 'ts']"
       />
-      <Cmip6MonthlyChart label="Sea Level Pressure" units="Pa" dataKey="psl" />
+      <Cmip6MonthlyChart
+        label="Sea Level Pressure"
+        units="Pa"
+        dataKey="psl"
+        class="mb-5"
+      />
       <Cmip6MonthlyChart label="Surface Temperature" units="°C" dataKey="ts" />
 
       <div v-if="latLng && apiData" class="my-6">

--- a/components/global/OceanographyCmip6.vue
+++ b/components/global/OceanographyCmip6.vue
@@ -9,34 +9,6 @@ const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const layers: MapLayer[] = [
   {
-    id: 'psl_cmip6_1950',
-    title: 'August 1950, EC-Earth3-Veg',
-    source: 'rasdaman',
-    wmsLayerName: 'cmip6_monthly',
-    style: 'ardac_psl',
-    legend: 'psl',
-    rasdamanConfiguration: {
-      dim_model: 2,
-      dim_scenario: 0,
-      time: '1950-08-15T12:00:00.000Z',
-    },
-    coastline: true,
-  },
-  {
-    id: 'psl_cmip6_1975',
-    title: 'August 1975, EC-Earth3-Veg',
-    source: 'rasdaman',
-    wmsLayerName: 'cmip6_monthly',
-    style: 'ardac_psl',
-    legend: 'psl',
-    rasdamanConfiguration: {
-      dim_model: 2,
-      dim_scenario: 0,
-      time: '1975-08-15T12:00:00.000Z',
-    },
-    coastline: true,
-  },
-  {
     id: 'psl_cmip6_2000',
     title: 'August 2000, EC-Earth3-Veg',
     source: 'rasdaman',
@@ -47,48 +19,6 @@ const layers: MapLayer[] = [
       dim_model: 2,
       dim_scenario: 0,
       time: '2000-08-15T12:00:00.000Z',
-    },
-    coastline: true,
-  },
-  {
-    id: 'psl_cmip6_2025',
-    title: 'August 2025, EC-Earth3-Veg, SSP5-8.5',
-    source: 'rasdaman',
-    wmsLayerName: 'cmip6_monthly',
-    style: 'ardac_psl',
-    legend: 'psl',
-    rasdamanConfiguration: {
-      dim_model: 2,
-      dim_scenario: 4,
-      time: '2025-08-15T12:00:00.000Z',
-    },
-    coastline: true,
-  },
-  {
-    id: 'psl_cmip6_2050',
-    title: 'August 2050, EC-Earth3-Veg, SSP5-8.5',
-    source: 'rasdaman',
-    wmsLayerName: 'cmip6_monthly',
-    style: 'ardac_psl',
-    legend: 'psl',
-    rasdamanConfiguration: {
-      dim_model: 2,
-      dim_scenario: 4,
-      time: '2050-08-15T12:00:00.000Z',
-    },
-    coastline: true,
-  },
-  {
-    id: 'psl_cmip6_2075',
-    title: 'August 2075, EC-Earth3-Veg, SSP5-8.5',
-    source: 'rasdaman',
-    wmsLayerName: 'cmip6_monthly',
-    style: 'ardac_psl',
-    legend: 'psl',
-    rasdamanConfiguration: {
-      dim_model: 2,
-      dim_scenario: 4,
-      time: '2075-08-15T12:00:00.000Z',
     },
     coastline: true,
   },
@@ -106,6 +36,34 @@ const layers: MapLayer[] = [
     },
     coastline: true,
   },
+  {
+    id: 'ts_cmip6_2000',
+    title: 'August 2000, EC-Earth3-Veg',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_ts',
+    legend: 'ts',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 0,
+      time: '2000-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'ts_cmip6_2100',
+    title: 'August 2100, EC-Earth3-Veg, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_ts',
+    legend: 'ts',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 4,
+      time: '2100-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
 ]
 
 const legend: Record<string, LegendItem[]> = {
@@ -116,9 +74,21 @@ const legend: Record<string, LegendItem[]> = {
     { color: '#fee090', label: '&ge;100750 Pa, &lt;101000 Pa' },
     { color: '#fc8d59', label: '&ge;101000 Pa' },
   ],
+  ts: [
+    { color: '#313695', label: '&lt;-20°C' },
+    { color: '#4575b4', label: '&ge;-20°C, &lt;-15°C' },
+    { color: '#74add1', label: '&ge;-15°C, &lt;-10°C' },
+    { color: '#abd9e9', label: '&ge;-10°C, &lt;-5°C' },
+    { color: '#e0f3f8', label: '&ge;-5°C, &lt;0°C' },
+    { color: '#fee090', label: '&ge;0°C, &lt;5°C' },
+    { color: '#fdae61', label: '&ge;5°C, &lt;10°C' },
+    { color: '#f46d43', label: '&ge;10°C, &lt;15°C' },
+    { color: '#d73027', label: '&ge;15°C, &lt;20°C' },
+    { color: '#a50026', label: '&ge;20°C' },
+  ],
 }
 
-const mapId = 'psl'
+const mapId = 'psl_and_ts'
 mapStore.setLegendItems(mapId, legend)
 
 onUnmounted(() => {
@@ -129,54 +99,54 @@ onUnmounted(() => {
 <template>
   <section class="section">
     <div class="content is-size-5">
-      <h3 class="title is-3">Sea Level Pressure, CMIP6</h3>
+      <h3 class="title is-3">Oceanography, CMIP6</h3>
       <p class="mb-6">
-        The map below shows modeled mean sea level pressure for the month of
-        August using the EC-Earth3-Veg model at 25-year intervals from
-        1950–2000. Intervals from 2025–2100 are based on the SSP5-8.5 emissions
-        scenario.
+        The map below shows modeled mean sea level pressure and surface
+        temperature for the month of August in the years 2000 and 2100 using the
+        EC-Earth3-Veg model. The maps for the year 2100 are based on the
+        SSP5-8.5 emissions scenario.
       </p>
 
       <MapBlock :mapId="mapId" class="mb-6">
         <template v-slot:layers>
+          <h4 class="title is-4 mb-3">Sea Level Pressure</h4>
           <MapLayer :mapId="mapId" :layer="layers[0]" default>
             <template v-slot:title>{{ layers[0].title }}</template>
           </MapLayer>
           <MapLayer :mapId="mapId" :layer="layers[1]">
             <template v-slot:title>{{ layers[1].title }}</template>
           </MapLayer>
+          <hr />
+          <h4 class="title is-4 mb-3">Surface Temperature</h4>
           <MapLayer :mapId="mapId" :layer="layers[2]">
             <template v-slot:title>{{ layers[2].title }}</template>
           </MapLayer>
           <MapLayer :mapId="mapId" :layer="layers[3]">
             <template v-slot:title>{{ layers[3].title }}</template>
           </MapLayer>
-          <MapLayer :mapId="mapId" :layer="layers[4]">
-            <template v-slot:title>{{ layers[4].title }}</template>
-          </MapLayer>
-          <MapLayer :mapId="mapId" :layer="layers[5]">
-            <template v-slot:title>{{ layers[5].title }}</template>
-          </MapLayer>
-          <MapLayer :mapId="mapId" :layer="layers[6]">
-            <template v-slot:title>{{ layers[6].title }}</template>
-          </MapLayer>
         </template>
       </MapBlock>
 
       <p>
-        Enter a location below to see a chart of the mean sea level pressure for
-        a point location using the selected model, emissions scenario, and
-        month. After entering a location, links will be provided where you can
-        download the data that is used to populate the chart.
+        Enter a location below to see charts of the mean sea level pressure and
+        surface temperature for a point location using the selected model,
+        emissions scenario, and month. After entering a location, links will be
+        provided where you can download the data that is used to populate the
+        charts.
       </p>
 
       <Gimme />
-      <Cmip6MonthlyChartControls defaultMonth="08" :datasetKeys="['psl']" />
+      <Cmip6MonthlyChartControls
+        defaultMonth="08"
+        :datasetKeys="['psl', 'ts']"
+      />
       <Cmip6MonthlyChart label="Sea Level Pressure" units="Pa" dataKey="psl" />
+      <Cmip6MonthlyChart label="Surface Temperature" units="°C" dataKey="ts" />
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download CMIP6 sea level pressure data for {{ latLng.lat }},
+          Download CMIP6 sea level pressure and surface temperature data for
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <ul>
@@ -188,7 +158,7 @@ onUnmounted(() => {
                 latLng.lat +
                 '/' +
                 latLng.lng +
-                '?vars=psl&format=csv'
+                '?vars=psl,ts&format=csv'
               "
               >Download as CSV</a
             >
@@ -201,7 +171,7 @@ onUnmounted(() => {
                 latLng.lat +
                 '/' +
                 latLng.lng +
-                '?vars=psl'
+                '?vars=psl,ts'
               "
               >Download as JSON</a
             >

--- a/components/global/PrecipitationCmip6.vue
+++ b/components/global/PrecipitationCmip6.vue
@@ -1,0 +1,214 @@
+<script lang="ts" setup>
+const placesStore = usePlacesStore()
+const mapStore = useMapStore()
+const dataStore = useDataStore()
+const runtimeConfig = useRuntimeConfig()
+
+const apiData = computed<any[]>(() => dataStore.apiData)
+const latLng = computed<LatLngValue>(() => placesStore.latLng)
+
+const layers: MapLayer[] = [
+  {
+    id: 'precipitation_cmip6_1950',
+    title: 'August 1950, EC-Earth3-Veg',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_pr',
+    legend: 'pr',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 0,
+      time: '1950-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'precipitation_cmip6_1975',
+    title: 'August 1975, EC-Earth3-Veg',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_pr',
+    legend: 'pr',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 0,
+      time: '1975-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'precipitation_cmip6_2000',
+    title: 'August 2000, EC-Earth3-Veg',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_pr',
+    legend: 'pr',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 0,
+      time: '2000-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'precipitation_cmip6_2025',
+    title: 'August 2025, EC-Earth3-Veg, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_pr',
+    legend: 'pr',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 4,
+      time: '2025-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'precipitation_cmip6_2050',
+    title: 'August 2050, EC-Earth3-Veg, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_pr',
+    legend: 'pr',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 4,
+      time: '2050-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'precipitation_cmip6_2075',
+    title: 'August 2075, EC-Earth3-Veg, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_pr',
+    legend: 'pr',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 4,
+      time: '2075-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'precipitation_cmip6_2100',
+    title: 'August 2100, EC-Earth3-Veg, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_pr',
+    legend: 'pr',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 4,
+      time: '2100-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+]
+
+const legend: Record<string, LegendItem[]> = {
+  pr: [
+    { color: '#edf8fbff', label: '&ge;0㎜, &lt;50㎜' },
+    { color: '#b2e2e2ff', label: '&ge;50㎜, &lt;100㎜' },
+    { color: '#66c2a4ff', label: '&ge;100㎜, &lt;150㎜' },
+    { color: '#2ca25fff', label: '&ge;150㎜, &lt;200㎜' },
+    { color: '#006d2cff', label: '&ge;200㎜' },
+  ],
+}
+
+const mapId = 'snow_melt'
+mapStore.setLegendItems(mapId, legend)
+
+onUnmounted(() => {
+  dataStore.apiData = null
+})
+</script>
+
+<template>
+  <section class="section">
+    <div class="content is-size-5">
+      <h3 class="title is-3">Precipitation, CMIP6</h3>
+      <p class="mb-6">
+        The map below shows modeled total precipitation for the month of August
+        using the EC-Earth3-Veg model at 25-year intervals from 1950–2000.
+        Intervals from 2025–2100 are based on the SSP5-8.5 emissions scenario.
+      </p>
+
+      <MapBlock :mapId="mapId" class="mb-6">
+        <template v-slot:layers>
+          <MapLayer :mapId="mapId" :layer="layers[0]" default>
+            <template v-slot:title>{{ layers[0].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[1]">
+            <template v-slot:title>{{ layers[1].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[2]">
+            <template v-slot:title>{{ layers[2].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[3]">
+            <template v-slot:title>{{ layers[3].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[4]">
+            <template v-slot:title>{{ layers[4].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[5]">
+            <template v-slot:title>{{ layers[5].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[6]">
+            <template v-slot:title>{{ layers[6].title }}</template>
+          </MapLayer>
+        </template>
+      </MapBlock>
+
+      <p>
+        Enter a location below to see a chart of the total monthly precipitation
+        for a point location using the selected model, emissions scenario, and
+        month. After entering a location, links will be provided where you can
+        download the data that is used to populate the chart.
+      </p>
+
+      <Gimme />
+      <Cmip6MonthlyChartControls defaultMonth="08" :datasetKeys="['pr']" />
+      <Cmip6MonthlyChart label="Precipitation" units="㎜" dataKey="pr" />
+
+      <div v-if="latLng && apiData" class="my-6">
+        <h4 class="title is-4">
+          Download CMIP6 precipitation data for {{ latLng.lat }},
+          {{ latLng.lng }}
+        </h4>
+        <ul>
+          <li>
+            <a
+              :href="
+                runtimeConfig.public.apiUrl +
+                '/cmip6/point/' +
+                latLng.lat +
+                '/' +
+                latLng.lng +
+                '?vars=pr&format=csv'
+              "
+              >Download as CSV</a
+            >
+          </li>
+          <li>
+            <a
+              :href="
+                runtimeConfig.public.apiUrl +
+                '/cmip6/point/' +
+                latLng.lat +
+                '/' +
+                latLng.lng +
+                '?vars=pr'
+              "
+              >Download as JSON</a
+            >
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style lang="scss" scoped></style>

--- a/components/global/SeaLevelPressureCmip6.vue
+++ b/components/global/SeaLevelPressureCmip6.vue
@@ -1,0 +1,215 @@
+<script lang="ts" setup>
+const placesStore = usePlacesStore()
+const mapStore = useMapStore()
+const dataStore = useDataStore()
+const runtimeConfig = useRuntimeConfig()
+
+const apiData = computed<any[]>(() => dataStore.apiData)
+const latLng = computed<LatLngValue>(() => placesStore.latLng)
+
+const layers: MapLayer[] = [
+  {
+    id: 'psl_cmip6_1950',
+    title: 'August 1950, EC-Earth3-Veg',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_psl',
+    legend: 'psl',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 0,
+      time: '1950-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'psl_cmip6_1975',
+    title: 'August 1975, EC-Earth3-Veg',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_psl',
+    legend: 'psl',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 0,
+      time: '1975-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'psl_cmip6_2000',
+    title: 'August 2000, EC-Earth3-Veg',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_psl',
+    legend: 'psl',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 0,
+      time: '2000-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'psl_cmip6_2025',
+    title: 'August 2025, EC-Earth3-Veg, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_psl',
+    legend: 'psl',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 4,
+      time: '2025-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'psl_cmip6_2050',
+    title: 'August 2050, EC-Earth3-Veg, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_psl',
+    legend: 'psl',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 4,
+      time: '2050-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'psl_cmip6_2075',
+    title: 'August 2075, EC-Earth3-Veg, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_psl',
+    legend: 'psl',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 4,
+      time: '2075-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'psl_cmip6_2100',
+    title: 'August 2100, EC-Earth3-Veg, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_psl',
+    legend: 'psl',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 4,
+      time: '2100-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+]
+
+const legend: Record<string, LegendItem[]> = {
+  psl: [
+    { color: '#4575b4', label: '&ge;100000 Pa, &lt;100250 Pa' },
+    { color: '#91bfdb', label: '&ge;100250 Pa, &lt;100500 Pa' },
+    { color: '#e0f3f8', label: '&ge;100500 Pa, &lt;100750 Pa' },
+    { color: '#fee090', label: '&ge;100750 Pa, &lt;101000 Pa' },
+    { color: '#fc8d59', label: '&ge;101000 Pa' },
+  ],
+}
+
+const mapId = 'psl'
+mapStore.setLegendItems(mapId, legend)
+
+onUnmounted(() => {
+  dataStore.apiData = null
+})
+</script>
+
+<template>
+  <section class="section">
+    <div class="content is-size-5">
+      <h3 class="title is-3">Sea Level Pressure, CMIP6</h3>
+      <p class="mb-6">
+        The map below shows modeled mean sea level pressure for the month of
+        August using the EC-Earth3-Veg model at 25-year intervals from
+        1950–2000. Intervals from 2025–2100 are based on the SSP5-8.5 emissions
+        scenario.
+      </p>
+
+      <MapBlock :mapId="mapId" class="mb-6">
+        <template v-slot:layers>
+          <MapLayer :mapId="mapId" :layer="layers[0]" default>
+            <template v-slot:title>{{ layers[0].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[1]">
+            <template v-slot:title>{{ layers[1].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[2]">
+            <template v-slot:title>{{ layers[2].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[3]">
+            <template v-slot:title>{{ layers[3].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[4]">
+            <template v-slot:title>{{ layers[4].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[5]">
+            <template v-slot:title>{{ layers[5].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[6]">
+            <template v-slot:title>{{ layers[6].title }}</template>
+          </MapLayer>
+        </template>
+      </MapBlock>
+
+      <p>
+        Enter a location below to see a chart of the mean sea level pressure for
+        a point location using the selected model, emissions scenario, and
+        month. After entering a location, links will be provided where you can
+        download the data that is used to populate the chart.
+      </p>
+
+      <Gimme />
+      <Cmip6MonthlyChartControls defaultMonth="08" :datasetKeys="['psl']" />
+      <Cmip6MonthlyChart label="Sea Level Pressure" units="Pa" dataKey="psl" />
+
+      <div v-if="latLng && apiData" class="my-6">
+        <h4 class="title is-4">
+          Download CMIP6 sea level pressure data for {{ latLng.lat }},
+          {{ latLng.lng }}
+        </h4>
+        <ul>
+          <li>
+            <a
+              :href="
+                runtimeConfig.public.apiUrl +
+                '/cmip6/point/' +
+                latLng.lat +
+                '/' +
+                latLng.lng +
+                '?vars=psl&format=csv'
+              "
+              >Download as CSV</a
+            >
+          </li>
+          <li>
+            <a
+              :href="
+                runtimeConfig.public.apiUrl +
+                '/cmip6/point/' +
+                latLng.lat +
+                '/' +
+                latLng.lng +
+                '?vars=psl'
+              "
+              >Download as JSON</a
+            >
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style lang="scss" scoped></style>

--- a/components/global/SolarRadiationCloudCoverCmip6.vue
+++ b/components/global/SolarRadiationCloudCoverCmip6.vue
@@ -1,0 +1,260 @@
+<script lang="ts" setup>
+const placesStore = usePlacesStore()
+const mapStore = useMapStore()
+const dataStore = useDataStore()
+const runtimeConfig = useRuntimeConfig()
+
+const apiData = computed<any[]>(() => dataStore.apiData)
+const latLng = computed<LatLngValue>(() => placesStore.latLng)
+
+const layers: MapLayer[] = [
+  {
+    id: 'rsds_cmip6_2000',
+    title: 'August 2000, HadGEM3-GC31-MM',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_rsds',
+    legend: 'rsds',
+    rasdamanConfiguration: {
+      dim_model: 5,
+      dim_scenario: 0,
+      time: '2000-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'rsds_cmip6_2100',
+    title: 'August 2100, HadGEM3-GC31-MM, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_rsds',
+    legend: 'rsds',
+    rasdamanConfiguration: {
+      dim_model: 5,
+      dim_scenario: 4,
+      time: '2100-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'rlds_cmip6_2000',
+    title: 'August 2000, HadGEM3-GC31-MM',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_rlds',
+    legend: 'rlds',
+    rasdamanConfiguration: {
+      dim_model: 5,
+      dim_scenario: 0,
+      time: '2000-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'rlds_cmip6_2100',
+    title: 'August 2100, HadGEM3-GC31-MM, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_rlds',
+    legend: 'rlds',
+    rasdamanConfiguration: {
+      dim_model: 5,
+      dim_scenario: 4,
+      time: '2100-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'clt_cmip6_2100',
+    title: 'August 2100, HadGEM3-GC31-MM, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_clt',
+    legend: 'clt',
+    rasdamanConfiguration: {
+      dim_model: 5,
+      dim_scenario: 4,
+      time: '2100-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+]
+
+const legend: Record<string, LegendItem[]> = {
+  rsds: [
+    {
+      color: '#ffffbf',
+      label: '&ge;0 W/m<sup>2</sup>, &lt;50 W/m<sup>2</sup>',
+    },
+    {
+      color: '#fee090',
+      label: '&ge;50 W/m<sup>2</sup>, &lt;100 W/m<sup>2</sup>',
+    },
+    {
+      color: '#fdae61',
+      label: '&ge;100 W/m<sup>2</sup>, &lt;150 W/m<sup>2</sup>',
+    },
+    {
+      color: '#f46d43',
+      label: '&ge;150 W/m<sup>2</sup>, &lt;200 W/m<sup>2</sup>',
+    },
+    {
+      color: '#d73027',
+      label: '&ge;200 W/m<sup>2</sup>',
+    },
+  ],
+  rlds: [
+    {
+      color: '#ffffbf',
+      label: '&ge;100 W/m<sup>100</sup>, &lt;175 W/m<sup>2</sup>',
+    },
+    {
+      color: '#fee090',
+      label: '&ge;175 W/m<sup>2</sup>, &lt;250 W/m<sup>2</sup>',
+    },
+    {
+      color: '#fdae61',
+      label: '&ge;250 W/m<sup>2</sup>, &lt;325 W/m<sup>2</sup>',
+    },
+    {
+      color: '#f46d43',
+      label: '&ge;325 W/m<sup>2</sup>, &lt;400 W/m<sup>2</sup>',
+    },
+    {
+      color: '#d73027',
+      label: '&ge;400 W/m<sup>2</sup>',
+    },
+  ],
+  clt: [
+    { color: '#045a8d', label: '&ge;0%, &lt;60%' },
+    { color: '#2b8cbe', label: '&ge;60%, &lt;70%' },
+    { color: '#74a9cf', label: '&ge;70%, &lt;80%' },
+    { color: '#bdc9e1', label: '&ge;80%, &lt;90%' },
+    { color: '#f1eef6', label: '&ge;90%' },
+  ],
+}
+
+const mapId = 'solar_radiation_and_cloud_cover'
+mapStore.setLegendItems(mapId, legend)
+
+onUnmounted(() => {
+  dataStore.apiData = null
+})
+</script>
+
+<template>
+  <section class="section">
+    <div class="content is-size-5">
+      <h3 class="title is-3">Solar Radiation & Cloud Cover, CMIP6</h3>
+      <p class="mb-6">
+        The map below shows modeled mean downwelling shortwave and longwave flux
+        and cloud area fraction (cloud cover) for the month of August in the
+        years 2000 and 2100 using the HadGEM3-GC31-MM model. The maps for the
+        year 2100 are based on the SSP5-8.5 emissions scenario.
+      </p>
+
+      <MapBlock :mapId="mapId" class="mb-6">
+        <template v-slot:layers>
+          <h4 class="title is-4 mb-3">Downwelling Shortwave Flux</h4>
+          <MapLayer :mapId="mapId" :layer="layers[0]" default>
+            <template v-slot:title>{{ layers[0].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[1]">
+            <template v-slot:title>{{ layers[1].title }}</template>
+          </MapLayer>
+          <hr />
+          <h4 class="title is-4 mb-3">Downwelling Longwave Flux</h4>
+          <MapLayer :mapId="mapId" :layer="layers[2]">
+            <template v-slot:title>{{ layers[2].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[3]">
+            <template v-slot:title>{{ layers[3].title }}</template>
+          </MapLayer>
+          <hr />
+          <h4 class="title is-4 mb-3">Cloud Area Fraction (Cloud Cover)</h4>
+          <MapLayer :mapId="mapId" :layer="layers[4]">
+            <template v-slot:title>{{ layers[4].title }}</template>
+          </MapLayer>
+        </template>
+      </MapBlock>
+
+      <p>
+        Enter a location below to see charts of downwelling flux, upward heat
+        flux, and cloud area fraction (cloud cover) for a point location using
+        the selected model, emissions scenario, and month. After entering a
+        location, links will be provided where you can download the data that is
+        used to populate the charts.
+      </p>
+
+      <Gimme />
+      <Cmip6MonthlyChartControls
+        defaultModel="HadGEM3-GC31-MM"
+        defaultMonth="08"
+        :datasetKeys="['rsds', 'rlds', 'hfss', 'hfls', 'clt']"
+      />
+      <Cmip6MonthlyChart
+        label="Downwelling Shortwave Flux"
+        units="W/m<sup>2</sup>"
+        dataKey="rsds"
+        class="mb-5"
+      />
+      <Cmip6MonthlyChart
+        label="Downwelling Longwave Flux"
+        units="W/m<sup>2</sup>"
+        dataKey="rlds"
+        class="mb-5"
+      />
+      <Cmip6MonthlyChart
+        label="Surface Upward Sensible Heat Flux"
+        units="W/m<sup>2</sup>"
+        dataKey="hfss"
+        class="mb-5"
+      />
+      <Cmip6MonthlyChart
+        label="Surface Upward Latent Heat Flux"
+        units="W/m<sup>2</sup>"
+        dataKey="hfls"
+        class="mb-5"
+      />
+      <Cmip6MonthlyChart label="Cloud Area Fraction" units="%" dataKey="clt" />
+
+      <div v-if="latLng && apiData" class="my-6">
+        <h4 class="title is-4">
+          Download CMIP6 downwelling flux, upward heat flux, and cloud area
+          fraction data for {{ latLng.lat }},
+          {{ latLng.lng }}
+        </h4>
+        <ul>
+          <li>
+            <a
+              :href="
+                runtimeConfig.public.apiUrl +
+                '/cmip6/point/' +
+                latLng.lat +
+                '/' +
+                latLng.lng +
+                '?vars=rsds,rlds,hfss,hfls,clt&format=csv'
+              "
+              >Download as CSV</a
+            >
+          </li>
+          <li>
+            <a
+              :href="
+                runtimeConfig.public.apiUrl +
+                '/cmip6/point/' +
+                latLng.lat +
+                '/' +
+                latLng.lng +
+                '?vars=rsds,rlds,hfss,hfls,clt'
+              "
+              >Download as JSON</a
+            >
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style lang="scss" scoped></style>

--- a/components/global/TemperatureCmip6.vue
+++ b/components/global/TemperatureCmip6.vue
@@ -1,0 +1,242 @@
+<script lang="ts" setup>
+const placesStore = usePlacesStore()
+const mapStore = useMapStore()
+const dataStore = useDataStore()
+const runtimeConfig = useRuntimeConfig()
+
+const apiData = computed<any[]>(() => dataStore.apiData)
+const latLng = computed<LatLngValue>(() => placesStore.latLng)
+
+const layers: MapLayer[] = [
+  {
+    id: 'tas_cmip6_2000',
+    title: '2000, GFDL-ESM4',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_tas',
+    legend: 'tas',
+    rasdamanConfiguration: {
+      dim_model: 3,
+      dim_scenario: 0,
+      time: '2000-07-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'tas_cmip6_2100',
+    title: '2100, GFDL-ESM4, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_tas',
+    legend: 'tas',
+    rasdamanConfiguration: {
+      dim_model: 3,
+      dim_scenario: 4,
+      time: '2100-07-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'tasmax_cmip6_2000',
+    title: '2000, GFDL-ESM4',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_tasmax',
+    legend: 'tas',
+    rasdamanConfiguration: {
+      dim_model: 3,
+      dim_scenario: 0,
+      time: '2000-07-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'tasmax_cmip6_2100',
+    title: '2100, GFDL-ESM4, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_tasmax',
+    legend: 'tas',
+    rasdamanConfiguration: {
+      dim_model: 3,
+      dim_scenario: 4,
+      time: '2100-07-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'tasmin_cmip6_2000',
+    title: '2000, GFDL-ESM4',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_tasmin',
+    legend: 'tas',
+    rasdamanConfiguration: {
+      dim_model: 3,
+      dim_scenario: 0,
+      time: '2000-01-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'tasmin_cmip6_2100',
+    title: '2100, GFDL-ESM4, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_tasmin',
+    legend: 'tas',
+    rasdamanConfiguration: {
+      dim_model: 3,
+      dim_scenario: 4,
+      time: '2100-01-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+]
+
+const legend: Record<string, LegendItem[]> = {
+  tas: [
+    { color: '#313695', label: '&lt;-20°C' },
+    { color: '#4575b4', label: '&ge;-20°C, &lt;-15°C' },
+    { color: '#74add1', label: '&ge;-15°C, &lt;-10°C' },
+    { color: '#abd9e9', label: '&ge;-10°C, &lt;-5°C' },
+    { color: '#e0f3f8', label: '&ge;-5°C, &lt;0°C' },
+    { color: '#fee090', label: '&ge;0°C, &lt;5°C' },
+    { color: '#fdae61', label: '&ge;5°C, &lt;10°C' },
+    { color: '#f46d43', label: '&ge;10°C, &lt;15°C' },
+    { color: '#d73027', label: '&ge;15°C, &lt;20°C' },
+    { color: '#a50026', label: '&ge;20°C' },
+  ],
+}
+
+const mapId = 'tas_and_ts'
+mapStore.setLegendItems(mapId, legend)
+
+onUnmounted(() => {
+  dataStore.apiData = null
+})
+</script>
+
+<template>
+  <section class="section">
+    <div class="content is-size-5">
+      <h3 class="title is-3">Temperature, CMIP6</h3>
+      <p class="mb-6">
+        The map below shows modeled mean near-surface air temperature for the
+        month of July, the maximum near-surface air temperature for the month of
+        July, and the minimum near-surface air temperature for the month of
+        January in the years 2000 and 2100 using the GFDL-ESM4 model. The maps
+        for the year 2100 are based on the SSP5-8.5 emissions scenario.
+      </p>
+
+      <MapBlock :mapId="mapId" class="mb-6">
+        <template v-slot:layers>
+          <h4 class="title is-4 mb-3">
+            July Mean Near-surface Air Temperature
+          </h4>
+          <MapLayer :mapId="mapId" :layer="layers[0]" default>
+            <template v-slot:title>{{ layers[0].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[1]">
+            <template v-slot:title>{{ layers[1].title }}</template>
+          </MapLayer>
+          <hr />
+          <h4 class="title is-4 mb-3">
+            July Maximum Near-surface Air Temperature
+          </h4>
+          <MapLayer :mapId="mapId" :layer="layers[2]">
+            <template v-slot:title>{{ layers[2].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[3]">
+            <template v-slot:title>{{ layers[3].title }}</template>
+          </MapLayer>
+          <hr />
+          <h4 class="title is-4 mb-3">
+            January Minimum Near-surface Air Temperature
+          </h4>
+          <MapLayer :mapId="mapId" :layer="layers[4]">
+            <template v-slot:title>{{ layers[4].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[5]">
+            <template v-slot:title>{{ layers[5].title }}</template>
+          </MapLayer>
+        </template>
+      </MapBlock>
+
+      <p>
+        Enter a location below to see charts of near-surface air temperature and
+        surface temperature for a point location using the selected model,
+        emissions scenario, and month. After entering a location, links will be
+        provided where you can download the data that is used to populate the
+        charts.
+      </p>
+
+      <Gimme />
+      <Cmip6MonthlyChartControls
+        defaultModel="GFDL-ESM4"
+        defaultMonth="07"
+        :datasetKeys="['tas', 'tasmax', 'tasmin', 'ts']"
+      />
+      <Cmip6MonthlyChart
+        label="Mean Near-surface Air Temperature"
+        units="°C"
+        dataKey="tas"
+        class="mb-5"
+      />
+      <Cmip6MonthlyChart
+        label="Maximum Near-surface Air Temperature"
+        units="°C"
+        dataKey="tasmax"
+        class="mb-5"
+      />
+      <Cmip6MonthlyChart
+        label="Mininum Near-surface Air Temperature"
+        units="°C"
+        dataKey="tasmin"
+        class="mb-5"
+      />
+      <Cmip6MonthlyChart
+        label="Mean Surface Temperature"
+        units="°C"
+        dataKey="ts"
+      />
+
+      <div v-if="latLng && apiData" class="my-6">
+        <h4 class="title is-4">
+          Download CMIP6 temperature data for {{ latLng.lat }},
+          {{ latLng.lng }}
+        </h4>
+        <ul>
+          <li>
+            <a
+              :href="
+                runtimeConfig.public.apiUrl +
+                '/cmip6/point/' +
+                latLng.lat +
+                '/' +
+                latLng.lng +
+                '?vars=tas,tasmax,tasmin,ts&format=csv'
+              "
+              >Download as CSV</a
+            >
+          </li>
+          <li>
+            <a
+              :href="
+                runtimeConfig.public.apiUrl +
+                '/cmip6/point/' +
+                latLng.lat +
+                '/' +
+                latLng.lng +
+                '?vars=tas,tasmax,tasmin,ts'
+              "
+              >Download as JSON</a
+            >
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style lang="scss" scoped></style>

--- a/components/global/TemperatureCmip6.vue
+++ b/components/global/TemperatureCmip6.vue
@@ -109,7 +109,7 @@ const legend: Record<string, LegendItem[]> = {
   ],
 }
 
-const mapId = 'tas_and_ts'
+const mapId = 'tas'
 mapStore.setLegendItems(mapId, legend)
 
 onUnmounted(() => {
@@ -164,18 +164,17 @@ onUnmounted(() => {
       </MapBlock>
 
       <p>
-        Enter a location below to see charts of near-surface air temperature and
-        surface temperature for a point location using the selected model,
-        emissions scenario, and month. After entering a location, links will be
-        provided where you can download the data that is used to populate the
-        charts.
+        Enter a location below to see charts of near-surface air temperature for
+        a point location using the selected model, emissions scenario, and
+        month. After entering a location, links will be provided where you can
+        download the data that is used to populate the charts.
       </p>
 
       <Gimme />
       <Cmip6MonthlyChartControls
         defaultModel="GFDL-ESM4"
         defaultMonth="07"
-        :datasetKeys="['tas', 'tasmax', 'tasmin', 'ts']"
+        :datasetKeys="['tas', 'tasmax', 'tasmin']"
       />
       <Cmip6MonthlyChart
         label="Mean Near-surface Air Temperature"
@@ -195,11 +194,6 @@ onUnmounted(() => {
         dataKey="tasmin"
         class="mb-5"
       />
-      <Cmip6MonthlyChart
-        label="Mean Surface Temperature"
-        units="°C"
-        dataKey="ts"
-      />
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
@@ -215,7 +209,7 @@ onUnmounted(() => {
                 latLng.lat +
                 '/' +
                 latLng.lng +
-                '?vars=tas,tasmax,tasmin,ts&format=csv'
+                '?vars=tas,tasmax,tasmin&format=csv'
               "
               >Download as CSV</a
             >
@@ -228,7 +222,7 @@ onUnmounted(() => {
                 latLng.lat +
                 '/' +
                 latLng.lng +
-                '?vars=tas,tasmax,tasmin,ts'
+                '?vars=tas,tasmax,tasmin'
               "
               >Download as JSON</a
             >

--- a/components/global/WindCmip6.vue
+++ b/components/global/WindCmip6.vue
@@ -1,0 +1,248 @@
+<script lang="ts" setup>
+const placesStore = usePlacesStore()
+const mapStore = useMapStore()
+const dataStore = useDataStore()
+const runtimeConfig = useRuntimeConfig()
+
+const apiData = computed<any[]>(() => dataStore.apiData)
+const latLng = computed<LatLngValue>(() => placesStore.latLng)
+
+const layers: MapLayer[] = [
+  {
+    id: 'sfcWind_cmip6_2000',
+    title: 'August 2000, EC-Earth3-Veg',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_sfcWind',
+    legend: 'sfcWind',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 0,
+      time: '2000-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'sfcWind_cmip6_2100',
+    title: 'August 2100, EC-Earth3-Veg, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_sfcWind',
+    legend: 'sfcWind',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 4,
+      time: '2100-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'uas_cmip6_2000',
+    title: 'August 2000, EC-Earth3-Veg',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_uas',
+    legend: 'uas',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 0,
+      time: '2000-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'uas_cmip6_2100',
+    title: 'August 2100, EC-Earth3-Veg, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_uas',
+    legend: 'uas',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 4,
+      time: '2100-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'vas_cmip6_2000',
+    title: 'August 2000, EC-Earth3-Veg',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_vas',
+    legend: 'vas',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 0,
+      time: '2000-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'vas_cmip6_2100',
+    title: 'August 2100, EC-Earth3-Veg, SSP5-8.5',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_vas',
+    legend: 'vas',
+    rasdamanConfiguration: {
+      dim_model: 2,
+      dim_scenario: 4,
+      time: '2100-08-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+]
+
+const legend: Record<string, LegendItem[]> = {
+  sfcWind: [
+    { color: '#252525', label: '&ge;0 m/s, &lt;1.5 m/s' },
+    { color: '#636363', label: '&ge;1.5 m/s, &lt;3 m/s' },
+    { color: '#969696', label: '&ge;3 m/s, &lt;4.5 m/s' },
+    { color: '#cccccc', label: '&ge;4.5 m/s, &lt;6 m/s' },
+    { color: '#f7f7f7', label: '&ge;6 m/s' },
+  ],
+  uas: [
+    { color: '#c51b7d', label: '&lt;-3 m/s' },
+    { color: '#de77ae', label: '&ge;-3 m/s, &lt;-2 m/s' },
+    { color: '#f1b6da', label: '&ge;-2 m/s, &lt;-1 m/s' },
+    { color: '#fde0ef', label: '&ge;-1 m/s, &lt;0 m/s' },
+    { color: '#e6f5d0', label: '&ge;0 m/s, &lt;1 m/s' },
+    { color: '#b8e186', label: '&ge;1 m/s, &lt;2 m/s' },
+    { color: '#7fbc41', label: '&ge;2 m/s, &lt;3 m/s' },
+    { color: '#4d9221', label: '&ge;3 m/s' },
+  ],
+  vas: [
+    { color: '#c51b7d', label: '&lt;-3 m/s' },
+    { color: '#de77ae', label: '&ge;-3 m/s, &lt;-2 m/s' },
+    { color: '#f1b6da', label: '&ge;-2 m/s, &lt;-1 m/s' },
+    { color: '#fde0ef', label: '&ge;-1 m/s, &lt;0 m/s' },
+    { color: '#e6f5d0', label: '&ge;0 m/s, &lt;1 m/s' },
+    { color: '#b8e186', label: '&ge;1 m/s, &lt;2 m/s' },
+    { color: '#7fbc41', label: '&ge;2 m/s, &lt;3 m/s' },
+    { color: '#4d9221', label: '&ge;3 m/s' },
+  ],
+}
+
+const mapId = 'wind'
+mapStore.setLegendItems(mapId, legend)
+
+onUnmounted(() => {
+  dataStore.apiData = null
+})
+</script>
+
+<template>
+  <section class="section">
+    <div class="content is-size-5">
+      <h3 class="title is-3">Wind, CMIP6</h3>
+      <p class="mb-6">
+        The map below shows modeled mean near-surface wind speed, mean
+        near-surface eastward wind speed, and near-surface northward wind speed
+        for the month of August in the years 2000 and 2100 using the
+        EC-Earth3-Veg model. The maps for the year 2100 are based on the
+        SSP5-8.5 emissions scenario.
+      </p>
+
+      <MapBlock :mapId="mapId" class="mb-6">
+        <template v-slot:layers>
+          <h4 class="title is-4 mb-3">August Near-surface Wind Speed</h4>
+          <MapLayer :mapId="mapId" :layer="layers[0]" default>
+            <template v-slot:title>{{ layers[0].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[1]">
+            <template v-slot:title>{{ layers[1].title }}</template>
+          </MapLayer>
+          <hr />
+          <h4 class="title is-4 mb-3">
+            August Near-surface Eastward Wind Speed
+          </h4>
+          <MapLayer :mapId="mapId" :layer="layers[2]">
+            <template v-slot:title>{{ layers[2].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[3]">
+            <template v-slot:title>{{ layers[3].title }}</template>
+          </MapLayer>
+          <hr />
+          <h4 class="title is-4 mb-3">
+            August Near-surface Northward Wind Speed
+          </h4>
+          <MapLayer :mapId="mapId" :layer="layers[4]">
+            <template v-slot:title>{{ layers[4].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[5]">
+            <template v-slot:title>{{ layers[5].title }}</template>
+          </MapLayer>
+        </template>
+      </MapBlock>
+
+      <p>
+        Enter a location below to see charts of the mean near-surface wind
+        speed, near-surface eastern wind speed, and near-surface northward wind
+        speed for a point location using the selected model, emissions scenario,
+        and month. After entering a location, links will be provided where you
+        can download the data that is used to populate the charts.
+      </p>
+
+      <Gimme />
+      <Cmip6MonthlyChartControls
+        defaultMonth="08"
+        :datasetKeys="['sfcWind', 'uas', 'vas']"
+      />
+      <Cmip6MonthlyChart
+        label="Near-surface Wind Speed"
+        units="m/s"
+        dataKey="sfcWind"
+        class="mb-5"
+      />
+      <Cmip6MonthlyChart
+        label="Near-surface Eastward Wind Speed"
+        units="m/s"
+        dataKey="uas"
+        class="mb-5"
+      />
+      <Cmip6MonthlyChart
+        label="Near-surface Northward Wind Speed"
+        units="m/s"
+        dataKey="vas"
+      />
+
+      <div v-if="latLng && apiData" class="my-6">
+        <h4 class="title is-4">
+          Download CMIP6 near-surface wind speed data for {{ latLng.lat }},
+          {{ latLng.lng }}
+        </h4>
+        <ul>
+          <li>
+            <a
+              :href="
+                runtimeConfig.public.apiUrl +
+                '/cmip6/point/' +
+                latLng.lat +
+                '/' +
+                latLng.lng +
+                '?vars=sfcWind,uas,vas&format=csv'
+              "
+              >Download as CSV</a
+            >
+          </li>
+          <li>
+            <a
+              :href="
+                runtimeConfig.public.apiUrl +
+                '/cmip6/point/' +
+                latLng.lat +
+                '/' +
+                latLng.lng +
+                '?vars=sfcWind,uas,vas'
+              "
+              >Download as JSON</a
+            >
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style lang="scss" scoped></style>

--- a/stores/data.ts
+++ b/stores/data.ts
@@ -6,6 +6,7 @@ const endpoints: Record<string, string> = {
   elevation: '/elevation/point/',
   flammability: '/alfresco/flammability/local/',
   beetles: '/beetles/point/',
+  cmip6Monthly: '/cmip6/point/',
   indicatorsCmip6: '/indicators/cmip6/point/',
   degreeDaysBelow0: '/degree_days/below_zero/',
   heatingDegreeDays: '/degree_days/heating/',
@@ -30,7 +31,7 @@ export const useDataStore = defineStore('data', () => {
   const apiData: any = ref(null)
   const dataError: Ref<boolean> = ref(false)
 
-  const fetchData = async (dataset: string) => {
+  const fetchData = async (dataset: string, params: string = '') => {
     if (placesStore.latLng === undefined) {
       return // do not try
     }
@@ -42,6 +43,11 @@ export const useDataStore = defineStore('data', () => {
       placesStore.latLng.lat +
       '/' +
       placesStore.latLng.lng
+
+    if (params) {
+      url += params
+    }
+
     try {
       const response = await fetch(url)
       const data = await response.json()

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -85,6 +85,18 @@ interface IndicatorsCmip6ChartInputs {
   scenario: string
 }
 
+interface Cmip6MonthlyChartLabels {
+  models: Record<string, string>
+  scenarios: Record<string, string>
+  months: Record<string, string>
+}
+
+interface Cmip6MonthlyChartInputs {
+  model: string
+  scenario: string
+  month: string
+}
+
 type LatLngValue = LatLng | undefined
 
 type PlaceType = 'community' | 'latLng' | undefined
@@ -97,3 +109,6 @@ type PermafrostChartInputsObj = PermafrostChartInputs | undefined
 
 type IndicatorsCmip6ChartLabelsObj = IndicatorsCmip6ChartLabels | undefined
 type IndicatorsCmip6ChartInputsObj = IndicatorsCmip6ChartInputs | undefined
+
+type Cmip6MonthlyChartLabelsObj = Cmip6MonthlyChartLabels | undefined
+type Cmip6MonthlyChartInputsObj = Cmip6MonthlyChartInputs | undefined

--- a/types/slugs.d.ts
+++ b/types/slugs.d.ts
@@ -64,3 +64,5 @@ type Slug =
   | 'story-beetle-climate-protection'
   | 'story-climate-stripes-1'
   | 'summary-landfast-sea-ice'
+  | 'evaporation-cmip6'
+  | 'sea-level-pressure-cmip6'

--- a/types/slugs.d.ts
+++ b/types/slugs.d.ts
@@ -54,7 +54,6 @@ type Slug =
   | 'oceanography-cmip6'
   | 'precipitation-cmip6'
   | 'sea-ice-cmip6'
-  | 'hydrology-cmip6'
   | 'solar-radiation-cloud-cover-cmip6'
   | 'snow-cmip6'
   | 'indicator-ftc-cmip6'
@@ -65,4 +64,3 @@ type Slug =
   | 'story-climate-stripes-1'
   | 'summary-landfast-sea-ice'
   | 'evaporation-cmip6'
-  | 'sea-level-pressure-cmip6'


### PR DESCRIPTION
Closes #145.
Xref: https://github.com/ua-snap/data-api/pull/472

This PR implements six new "data x-ray" items based on the new CMIP6 monthly coverage on Apollo.

To test, run the data-api off the `cmip6_monthly` branch, pointed at Apollo:

```
cd data-api
git checkout cmip6_monthly
export FLASK_APP=application.py
export API_RAS_BASE_URL=https://apollo.snap.uaf.edu/rasdaman/
pipenv run flask run
```

Then run ARDAC Explorer, pointed at your local API and Apollo:

```
cd ardac-explorer
git checkout cmip6_monthly
export SNAP_API_URL=http://localhost:5000
export RASDAMAN_URL=https://apollo.snap.uaf.edu/rasdaman/ows
npm run dev
```

Then, test drive the maps & charts on the following items:

http://localhost:3000/item/temperature-cmip6
http://localhost:3000/item/wind-cmip6
http://localhost:3000/item/oceanography-cmip6
http://localhost:3000/item/precipitation-cmip6
http://localhost:3000/item/evaporation-cmip6
http://localhost:3000/item/solar-radiation-cloud-cover-cmip6