### PR TITLE
Fix units in CMIP6 rx1day chart from m to mm

### DIFF
--- a/components/global/IndicatorRx1dayCmip6.vue
+++ b/components/global/IndicatorRx1dayCmip6.vue
@@ -94,7 +94,7 @@ mapStore.setLegendItems(mapId, legend)
       <IndicatorsCmip6ChartControls />
       <IndicatorsCmip6Chart
         label="Maximum 1-day precipitation"
-        units="m"
+        units="㎜"
         dataKey="rx1day"
       />
 


### PR DESCRIPTION
This PR simply updates the y-axis unit label in the CMIP6 "Maximum 1-day Precipitation" charts from `m` to `㎜`. This is necessary because the new `cmip6_indicators_new` coverage has precipitation values that have already been converted millimeters, whereas the old `cmip6_indicators` coverage used meters.