### PR TITLE
Update CMIP6 Summer Days map on Arctic Climate Data Node story

### DIFF
--- a/components/global/StoryArcticClimateDataNode.vue
+++ b/components/global/StoryArcticClimateDataNode.vue
@@ -10,30 +10,33 @@ const latLng = computed<LatLngValue>(() => placesStore.latLng)
 const layers: MapLayer[] = [
   {
     id: 'indicator_su_historical_era',
-    title: '1980–2009, GFDL-ESM4',
+    title: '1980–2009, TaiESM1',
     source: 'rasdaman',
     wmsLayerName: 'cmip6_indicators',
     style: 'ardac_indicator_su_historical_era',
     legend: 'summer_days',
-    rasdamanConfiguration: { dim_model: 4, dim_scenario: 0 },
+    rasdamanConfiguration: { dim_model: 11, dim_scenario: 0 },
+    coastline: true,
   },
   {
     id: 'indicator_su_midcentury_era',
-    title: '2040–2069, GFDL-ESM4, SSP5-8.5',
+    title: '2040–2069, TaiESM1, SSP5-8.5',
     source: 'rasdaman',
     wmsLayerName: 'cmip6_indicators',
     style: 'ardac_indicator_su_midcentury_era',
     legend: 'summer_days',
-    rasdamanConfiguration: { dim_model: 4, dim_scenario: 4 },
+    rasdamanConfiguration: { dim_model: 11, dim_scenario: 4 },
+    coastline: true,
   },
   {
     id: 'indicator_su_latecentury_era',
-    title: '2070–2099, GFDL-ESM4, SSP5-8.5',
+    title: '2070–2099, TaiESM1, SSP5-8.5',
     source: 'rasdaman',
     wmsLayerName: 'cmip6_indicators',
     style: 'ardac_indicator_su_latecentury_era',
     legend: 'summer_days',
-    rasdamanConfiguration: { dim_model: 4, dim_scenario: 4 },
+    rasdamanConfiguration: { dim_model: 11, dim_scenario: 4 },
+    coastline: true,
   },
 ]
 
@@ -222,9 +225,9 @@ onMounted(() => {
           Summer days are the number of days per year that are above 25&deg;C
           &lpar;77&deg;F&rpar;. The map below shows the 30-year mean of summer
           days using CMIP6 temperature data for three eras. The historical era
-          (1980&ndash;2009) uses model baseline data from the GFDL-ESM4 dataset.
+          (1980&ndash;2009) uses model baseline data from the TaiESM1 dataset.
           The mid-century era (2040&ndash;2069) and late-century era
-          (2070&ndash;2099) use GFDL-ESM4 data under the climate scenario
+          (2070&ndash;2099) use TaiESM1 data under the climate scenario
           SSP5-8.5 scenario.
         </p>
       </div>


### PR DESCRIPTION
This PR updates the CMIP6 Summer Days map on the Arctic Climate Data Node data story to:

- Reflect the different model axis mapping from the new `cmip6_indicators` coverage. `GFDL-ESM4` is now at position 3, not 4, so the page is currently not correct.
- Updates the CMIP6 Summer Days map on the page to use the model `TaiESM1` (at model axis position 11), same as the CMIP6 indicator x-ray items, since this model produces more interesting maps and more interesting changes between eras.

To test, run the app and look at the CMIP6 Summer Days map layers & surrounding text on this page:

http://localhost:3000/item/story-arctic-climate-data-node