### PR TITLE
Reduce duplicate API requests triggered when charts are drawn

### DIFF
--- a/components/HydrologyChart.vue
+++ b/components/HydrologyChart.vue
@@ -132,8 +132,6 @@ watch([apiData, chartLabels, chartInputs], async () => {
 
 watch(latLng, async () => {
   $Plotly.purge(chartId.value)
-  dataStore.apiData = null
-  dataStore.fetchData('hydrology')
 })
 
 onUnmounted(() => {

--- a/components/HydrologyChartControls.vue
+++ b/components/HydrologyChartControls.vue
@@ -48,6 +48,12 @@ watch([latLng, scenarioInput, monthInput], async () => {
     month: monthInput.value,
   }
 })
+
+watch(latLng, async () => {
+  dataStore.apiData = null
+  dataStore.fetchData('hydrology')
+})
+
 </script>
 
 <template>

--- a/components/IndicatorsCmip6Chart.vue
+++ b/components/IndicatorsCmip6Chart.vue
@@ -233,8 +233,6 @@ watch([apiData, chartLabels, chartInputs], async () => {
 
 watch(latLng, async () => {
   $Plotly.purge('chart')
-  dataStore.apiData = null
-  dataStore.fetchData('indicatorsCmip6')
 })
 
 onUnmounted(() => {

--- a/components/IndicatorsCmip6ChartControls.vue
+++ b/components/IndicatorsCmip6ChartControls.vue
@@ -51,6 +51,11 @@ const scenarioPresent = (value: string) => {
   }
 }
 
+watch(latLng, async () => {
+  dataStore.apiData = null
+  dataStore.fetchData('indicatorsCmip6')
+})
+
 watch([latLng, modelInput, scenarioInput], async () => {
   if (!scenarioPresent(scenarioInput.value)) {
     scenarioInput.value = defaultScenario

--- a/components/PermafrostChart.vue
+++ b/components/PermafrostChart.vue
@@ -221,8 +221,6 @@ watch([apiData, chartInputs], async () => {
 
 watch(latLng, async () => {
   $Plotly.purge(chartId.value)
-  dataStore.apiData = null
-  dataStore.fetchData('permafrost')
 })
 
 onUnmounted(() => {

--- a/components/PermafrostChartControls.vue
+++ b/components/PermafrostChartControls.vue
@@ -20,6 +20,11 @@ chartStore.labels = {
   scenarios: { 'RCP 4.5': 'RCP 4.5', 'RCP 8.5': 'RCP 8.5' },
 }
 
+watch(latLng, async () => {
+  dataStore.apiData = null
+  dataStore.fetchData('permafrost')
+})
+
 watch([latLng, scenarioInput], async () => {
   chartStore.inputs = {
     scenario: scenarioInput.value,


### PR DESCRIPTION
Closes #118 

Testing:
 - Point app at dev API endpoint: `export SNAP_API_URL=https://development.earthmaps.io`
 - For each of these, keep the dev console open and verify that
    1. the data fetch works / charts populate and
    2. only one HTTP request is fired.  Test all these:

http://localhost:3000/item/permafrost-base-top
http://localhost:3000/item/permafrost-magt
http://localhost:3000/item/indicator-su-cmip6

(Hydrology needs to be tested later, see #162)


