### PR TITLE
Clamp yaxis for (some) xray items

### DIFF
--- a/components/Cmip6MonthlyChart.vue
+++ b/components/Cmip6MonthlyChart.vue
@@ -6,7 +6,6 @@ const props = defineProps<{
 }>()
 
 import type { Data } from 'plotly.js-dist-min'
-import { monthMinMax } from '~/utils/math'
 import { isProxy, toRaw } from 'vue'
 
 const { $Plotly, $_ } = useNuxtApp()
@@ -29,6 +28,25 @@ const validChart = ref(true)
 
 const chartMin = ref(undefined)
 const chartMax = ref(undefined)
+
+// Get min/max values for the selected month of CMIP6 monthly charts.
+const monthMinMax = (values: any, month: string, dataKey: string) => {
+  let monthValues = <any>[]
+  Object.values(values).forEach((scenarios:any) => {
+    Object.values(scenarios).forEach((months:any) => {
+      Object.entries(months).forEach(([key, value]) => {
+        let last2 = key.slice(-2)
+        if (last2 == month) {
+          let typed = value as any
+          monthValues.push(typed[dataKey])
+        }
+      })
+    })
+  })
+  let min = $_.min(monthValues)
+  let max = $_.max(monthValues)
+  return { min: min, max: max }
+}
 
 const buildChart = () => {
   if (apiData.value && chartLabels.value && chartInputs.value) {

--- a/components/Cmip6MonthlyChart.vue
+++ b/components/Cmip6MonthlyChart.vue
@@ -6,8 +6,8 @@ const props = defineProps<{
 }>()
 
 import type { Data } from 'plotly.js-dist-min'
-import { deepMaxMeanMonth, deepMinMeanMonth } from '~/utils/math'
-import { isProxy, toRaw } from 'vue';
+import { monthMinMax } from '~/utils/math'
+import { isProxy, toRaw } from 'vue'
 
 const { $Plotly, $_ } = useNuxtApp()
 const dataStore = useDataStore()
@@ -37,7 +37,7 @@ const buildChart = () => {
     let projectedStartYear = 2015
 
     // Unwrap for performance reasons
-    if(isProxy(chartData)) {
+    if (isProxy(chartData)) {
       chartData = toRaw(chartData)
     }
 
@@ -65,8 +65,7 @@ const buildChart = () => {
     let scenario: string
     let allChartValues: Array<number | null> = []
 
-    let min = deepMinMeanMonth(chartData, month)
-    let max = deepMaxMeanMonth(chartData, month)
+    let { min, max } = monthMinMax(chartData, month, props.dataKey)
 
     traceConfig.forEach(config => {
       let values: Array<number | null> = []

--- a/components/IndicatorsCmip6Chart.vue
+++ b/components/IndicatorsCmip6Chart.vue
@@ -25,6 +25,29 @@ const chartInputs = computed<IndicatorsCmip6ChartInputsObj>(
 
 let chartData: any
 
+// Get min/max values for the selected month of CMIP6 monthly charts.
+const minMax = (chartData: any) => {
+  let dataKey = 'ftc'
+
+  let flatValues: number[] = []
+  Object.values(chartData).forEach((scenarios: any) => {
+    Object.values(scenarios).forEach((model: any) => {
+      if (model) {
+        Object.entries(model).forEach(([key, value]) => {
+          if (value) {
+            let indicatorObj = value as any
+            let v = parseFloat(indicatorObj[dataKey])
+            flatValues.push(v)
+          }
+        })
+      }
+    })
+  })
+  let min = $_.min(flatValues)
+  let max = $_.max(flatValues)
+  return { min: min, max: max }
+}
+
 const getPlotValues = (params: any) => {
   let years = $_.range(params.minYear, params.maxYear + 1)
 
@@ -111,6 +134,13 @@ const buildChart = () => {
     let traces: Data[] = []
     let allDecades: string[] = []
     chartData = dataStore.apiData
+
+    // Unwrap for performance reasons
+    if (isProxy(chartData)) {
+      chartData = toRaw(chartData)
+    }
+
+    let { min, max } = minMax(chartData)
 
     for (let i = 1950; i <= 2100; i += 10) {
       allDecades.push(i + '-' + (i + 9))
@@ -206,6 +236,8 @@ const buildChart = () => {
               size: 18,
             },
           },
+          range: [min, max],
+          fixedrange: true,
         },
       },
       {

--- a/components/IndicatorsCmip6Chart.vue
+++ b/components/IndicatorsCmip6Chart.vue
@@ -27,8 +27,6 @@ let chartData: any
 
 // Get min/max values for the selected month of CMIP6 monthly charts.
 const minMax = (chartData: any) => {
-  let dataKey = 'ftc'
-
   let flatValues: number[] = []
   Object.values(chartData).forEach((scenarios: any) => {
     Object.values(scenarios).forEach((model: any) => {
@@ -36,7 +34,7 @@ const minMax = (chartData: any) => {
         Object.entries(model).forEach(([key, value]) => {
           if (value) {
             let indicatorObj = value as any
-            let v = parseFloat(indicatorObj[dataKey])
+            let v = parseFloat(indicatorObj[props.dataKey])
             flatValues.push(v)
           }
         })

--- a/utils/math.js
+++ b/utils/math.js
@@ -6,3 +6,50 @@ export const precisionMean = values => {
   let mean = $_.mean(values)
   return diff < 10 ? $_.round(mean, 1) : $_.round(mean)
 }
+
+export const deepMinMeanMonth = (values, month) => {
+  let monthRegexp = new RegExp(`\\d\\d\\d\\d-${month}`)
+  let picked = $_.pickDeep(values, monthRegexp)
+  let min = deepMin(picked)
+  return min
+}
+
+export const deepMaxMeanMonth = (values, month) => {
+  let monthRegexp = new RegExp(`\\d\\d\\d\\d-${month}`)
+  let picked = $_.pickDeep(values, monthRegexp)
+  let max = deepMax(picked)
+  return max
+}
+
+export const deepMin = values => {
+  let min = deepCompare(values, (a, b) => { return a < b })
+  return min
+}
+
+export const deepMax = values => {
+  let min = deepCompare(values, (a, b) => { return a > b })
+  return min
+}
+
+// Comparator is a function that takes two arguments (value, acc)
+// and returns a boolean.
+export const deepCompare = (values, comparator) => {
+  let min = $_.reduceDeep(values,
+    (acc, value) => {
+      if(typeof acc == 'number' && typeof value == 'number') {
+        if(comparator(value, acc)) {
+          return value
+        } else {
+          return acc
+        }
+      } else {
+        // Waiting for tree navigation to hit its first leaf
+        if(typeof value == 'number') {
+          return value
+        }
+      }
+      return acc
+    }
+  );
+  return min
+}

--- a/utils/math.js
+++ b/utils/math.js
@@ -6,21 +6,3 @@ export const precisionMean = values => {
   let mean = $_.mean(values)
   return diff < 10 ? $_.round(mean, 1) : $_.round(mean)
 }
-
-// Get min/max values for the selected month of CMIP6 monthly charts.
-export const monthMinMax = (values, month, dataKey) => {
-  let monthValues = []
-  Object.values(values).forEach(scenarios => {
-    Object.values(scenarios).forEach(months => {
-      Object.entries(months).forEach(([key, value]) => {
-        let last2 = key.slice(-2)
-        if (last2 == month) {
-          monthValues.push(value[dataKey])
-        }
-      })
-    })
-  })
-  let min = $_.min(monthValues)
-  let max = $_.max(monthValues)
-  return { min: min, max: max }
-}

--- a/utils/math.js
+++ b/utils/math.js
@@ -7,49 +7,20 @@ export const precisionMean = values => {
   return diff < 10 ? $_.round(mean, 1) : $_.round(mean)
 }
 
-export const deepMinMeanMonth = (values, month) => {
-  let monthRegexp = new RegExp(`\\d\\d\\d\\d-${month}`)
-  let picked = $_.pickDeep(values, monthRegexp)
-  let min = deepMin(picked)
-  return min
-}
-
-export const deepMaxMeanMonth = (values, month) => {
-  let monthRegexp = new RegExp(`\\d\\d\\d\\d-${month}`)
-  let picked = $_.pickDeep(values, monthRegexp)
-  let max = deepMax(picked)
-  return max
-}
-
-export const deepMin = values => {
-  let min = deepCompare(values, (a, b) => { return a < b })
-  return min
-}
-
-export const deepMax = values => {
-  let min = deepCompare(values, (a, b) => { return a > b })
-  return min
-}
-
-// Comparator is a function that takes two arguments (value, acc)
-// and returns a boolean.
-export const deepCompare = (values, comparator) => {
-  let min = $_.reduceDeep(values,
-    (acc, value) => {
-      if(typeof acc == 'number' && typeof value == 'number') {
-        if(comparator(value, acc)) {
-          return value
-        } else {
-          return acc
+// Get min/max values for the selected month of CMIP6 monthly charts.
+export const monthMinMax = (values, month, dataKey) => {
+  let monthValues = []
+  Object.values(values).forEach(scenarios => {
+    Object.values(scenarios).forEach(months => {
+      Object.entries(months).forEach(([key, value]) => {
+        let last2 = key.slice(-2)
+        if (last2 == month) {
+          monthValues.push(value[dataKey])
         }
-      } else {
-        // Waiting for tree navigation to hit its first leaf
-        if(typeof value == 'number') {
-          return value
-        }
-      }
-      return acc
-    }
-  );
-  return min
+      })
+    })
+  })
+  let min = $_.min(monthValues)
+  let max = $_.max(monthValues)
+  return { min: min, max: max }
 }


### PR DESCRIPTION
Refs #154 

This PR clamps the y-axis when switching between scenario/model combinations, so that it's easier to visually compare how different models look for the same variable/indicator.  This currently applies only to the CMIP6 variables and CMIP6 indicators.

Testing:

- `export SNAP_API_URL=https://development.earthmaps.io/`
- For every CMIP6 variable, try switching between models/scenarios: the y-axis should be fixed.  Changing month will recalibrate the y-axis.  (y-range is computed on a per-chart basis, so for Temp, the mean/max/min will all have different y-ranges.
- For every CMIP6 indicator, switch model/scenarios.  Y axis will stay clamped.

