### PR TITLE
Purge CMIP6 Plotly charts only if they successfully loaded previously

### DIFF
--- a/components/Cmip6MonthlyChart.vue
+++ b/components/Cmip6MonthlyChart.vue
@@ -26,14 +26,11 @@ const chartInputs = computed<Cmip6MonthlyChartInputsObj>(
 const chartId = computed<string>(() => props.dataKey + '-chart')
 const validChart = ref(true)
 
-const chartMin = ref(undefined)
-const chartMax = ref(undefined)
-
 // Get min/max values for the selected month of CMIP6 monthly charts.
 const monthMinMax = (values: any, month: string, dataKey: string) => {
   let monthValues = <any>[]
-  Object.values(values).forEach((scenarios:any) => {
-    Object.values(scenarios).forEach((months:any) => {
+  Object.values(values).forEach((scenarios: any) => {
+    Object.values(scenarios).forEach((months: any) => {
       Object.entries(months).forEach(([key, value]) => {
         let last2 = key.slice(-2)
         if (last2 == month) {
@@ -191,16 +188,26 @@ const buildChart = () => {
   }
 }
 
+const purgeChart = () => {
+  if (validChart.value) {
+    $Plotly.purge(chartId.value)
+  }
+}
+
 watch([apiData, chartLabels, chartInputs], async () => {
+  purgeChart()
+
+  // Need to wait until nextTick to trigger v-if of the chart div.
   validChart.value = true
-  $Plotly.purge(chartId.value)
+  await nextTick()
+
   if (apiData.value) {
     buildChart()
   }
 })
 
 watch(latLng, async () => {
-  $Plotly.purge(chartId.value)
+  purgeChart()
 })
 
 onUnmounted(() => {


### PR DESCRIPTION
Closes #170.

This PR fixes console errors that occur when Plotly attempts to purge a chart that had not previously loaded. This fix applies to only the CMIP6 monthly charts, which are also the only charts that exhibit this problem due to the conditional chart loading we have in place since some CMIP6 models don't provide every variable (e.g., `tasmin` and `tasmax`).

To test, run ARDAC Explorer against the development API:

```
export SNAP_API_URL=https://development.earthmaps.io
npm run dev
```

Then make sure your browser's console is open, then visit:

http://localhost:3000/item/temperature-cmip6

Enter a location (e.g., "Fairbanks") to load the charts for the default TaiESM1 model, then select the model above it (NorESM2-MM), then select the model above that (MRI-ESM2-0). If you see no console errors, the fix works as intended.

This PR also removes two unused variables, `chartMin` and `chartMax`, btw.