### PR TITLE
Add model selection feature to all hydrology charts

### DIFF
--- a/components/HydrologyChart.vue
+++ b/components/HydrologyChart.vue
@@ -49,9 +49,10 @@ const buildChart = () => {
     let means: number[] = []
 
     decades.forEach(decade => {
+      let model = chartInputs.value!.model
       let scenario = chartInputs.value!.scenario
       let month = chartInputs.value!.month
-      let decadeData = chartData['CanESM2'][scenario][month][decade]
+      let decadeData = chartData[model][scenario][month][decade]
       let mean = decadeData[props.dataKey]
       means.push(mean)
     })
@@ -84,7 +85,9 @@ const buildChart = () => {
             ', ' +
             placesStore.latLng?.lng +
             '<br />' +
-            'Scenario: ' +
+            'Model: ' +
+            chartLabels.value.models[chartInputs.value.model] +
+            ', Scenario: ' +
             chartLabels.value.scenarios[chartInputs.value.scenario] +
             ', Month: ' +
             chartLabels.value.months[chartInputs.value.month],

--- a/components/HydrologyChartControls.vue
+++ b/components/HydrologyChartControls.vue
@@ -7,6 +7,7 @@ const dataStore = useDataStore()
 const placesStore = usePlacesStore()
 const chartStore = useChartStore()
 
+const modelInput = defineModel('model', { default: 'CanESM2' })
 const scenarioInput = defineModel('scenario', { default: 'rcp85' })
 const monthInput = defineModel('month', { default: 'mar' })
 
@@ -22,6 +23,18 @@ const chartLabels = computed<HydrologyChartLabels>(
 )
 
 chartStore.labels = {
+  models: {
+    'ACCESS1-3': 'ACCESS1-3',
+    CCSM4: 'CCSM4',
+    'CSIRO-Mk3-6-0': 'CSIRO-Mk3-6-0',
+    CanESM2: 'CanESM2',
+    'GFDL-ESM2M': 'GFDL-ESM2M',
+    'HadGEM2-ES': 'HadGEM2-ES',
+    inmcm4: 'INMCM4.0',
+    MIROC5: 'MIROC5',
+    'MPI-ESM-MR': 'MPI-ESM-MR',
+    'MRI-CGCM3': 'MRI-CGCM3',
+  },
   scenarios: {
     rcp45: 'RCP 4.5',
     rcp85: 'RCP 8.5',
@@ -42,8 +55,9 @@ chartStore.labels = {
   },
 }
 
-watch([latLng, scenarioInput, monthInput], async () => {
+watch([latLng, modelInput, scenarioInput, monthInput], async () => {
   chartStore.inputs = {
+    model: modelInput.value,
     scenario: scenarioInput.value,
     month: monthInput.value,
   }
@@ -53,11 +67,23 @@ watch(latLng, async () => {
   dataStore.apiData = null
   dataStore.fetchData('hydrology')
 })
-
 </script>
 
 <template>
   <div v-if="latLng && chartLabels && apiData">
+    <div class="parameter">
+      <label for="model" class="label">Model:</label>
+      <div class="select mb-5 mr-3">
+        <select id="model" v-model="modelInput">
+          <option
+            v-for="model in Object.keys(chartLabels.models)"
+            :value="model"
+          >
+            {{ chartLabels.models[model] }}
+          </option>
+        </select>
+      </div>
+    </div>
     <div class="parameter">
       <label for="scenario" class="label">Scenario:</label>
       <div class="select mb-5 mr-3">

--- a/components/global/HydrologyEvap.vue
+++ b/components/global/HydrologyEvap.vue
@@ -81,10 +81,9 @@ onUnmounted(() => {
 
       <p>
         Enter a location below to see a chart of mean annual evapotranspiration
-        per decade for a point location using the CanESM2 model and the selected
-        emissions scenario and month. After entering a location, links will be
-        provided where you can download the data that is used to populate the
-        chart.
+        per decade for a point location using the selected model, emissions
+        scenario, and month. After entering a location, links will be provided
+        where you can download the data that is used to populate the chart.
       </p>
 
       <Gimme extent="mizukami" />

--- a/components/global/HydrologyGlacierMelt.vue
+++ b/components/global/HydrologyGlacierMelt.vue
@@ -81,10 +81,9 @@ onUnmounted(() => {
 
       <p>
         Enter a location below to see a chart of mean annual glacier melt per
-        decade for a point location using the CanESM2 model and the selected
-        emissions scenario and month. After entering a location, links will be
-        provided where you can download the data that is used to populate the
-        chart.
+        decade for a point location using the selected model, emissions
+        scenario, and month. After entering a location, links will be provided
+        where you can download the data that is used to populate the chart.
       </p>
 
       <Gimme extent="mizukami" />

--- a/components/global/HydrologyIswe.vue
+++ b/components/global/HydrologyIswe.vue
@@ -124,11 +124,11 @@ onUnmounted(() => {
       </MapBlock>
 
       <p>
-        Enter a location below to see decadal charts of monthly mean ice/snow
-        water equivalent for a point location using the CanESM2 model and the
-        selected emissions scenario and month. After entering a location, links
-        will be provided where you can download the data that is used to
-        populate the charts.
+        Enter a location below to see charts of mean annual ice/snow water
+        equivalent per decade for a point location using the selected model,
+        emissions scenario, and month. After entering a location, links will be
+        provided where you can download the data that is used to populate the
+        charts.
       </p>
 
       <Gimme extent="mizukami" />

--- a/components/global/HydrologyRunoff.vue
+++ b/components/global/HydrologyRunoff.vue
@@ -81,9 +81,9 @@ onUnmounted(() => {
 
       <p>
         Enter a location below to see a chart of mean annual runoff per decade
-        for a point location using the CanESM2 model and the selected emissions
-        scenario and month. After entering a location, links will be provided
-        where you can download the data that is used to populate the chart.
+        for a point location using the selected model, emissions scenario, and
+        month. After entering a location, links will be provided where you can
+        download the data that is used to populate the chart.
       </p>
 
       <Gimme extent="mizukami" />

--- a/components/global/HydrologySm.vue
+++ b/components/global/HydrologySm.vue
@@ -168,10 +168,9 @@ onUnmounted(() => {
 
       <p>
         Enter a location below to see charts of mean monthly soil moisture per
-        decade for a point location using the CanESM2 model and the selected
-        emissions scenario and month. After entering a location, links will be
-        provided where you can download the data that is used to populate the
-        charts.
+        decade for a point location using the selected model, emissions
+        scenario, and month. After entering a location, links will be provided
+        where you can download the data that is used to populate the charts.
       </p>
 
       <Gimme extent="mizukami" />

--- a/components/global/HydrologySnowMelt.vue
+++ b/components/global/HydrologySnowMelt.vue
@@ -81,10 +81,9 @@ onUnmounted(() => {
 
       <p>
         Enter a location below to see a chart of mean annual snow melt per
-        decade for a point location using the CanESM2 model and the selected
-        emissions scenario and month. After entering a location, links will be
-        provided where you can download the data that is used to populate the
-        chart.
+        decade for a point location using the selected model, emissions
+        scenario, and month. After entering a location, links will be provided
+        where you can download the data that is used to populate the chart.
       </p>
 
       <Gimme extent="mizukami" />

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -61,11 +61,13 @@ interface LatLng {
 }
 
 interface HydrologyChartLabels {
+  models: Record<string, string>
   scenarios: Record<string, string>
   months: Record<string, string>
 }
 
 interface HydrologyChartInputs {
+  model: string
   scenario: string
   month: string
 }


### PR DESCRIPTION
Closes #146.

This PR adds the same model selection feature we have for other ARDAC's items to all hydrology charts.

To test, first uncomment the hydrology slugs in `slugs.d.ts` so the corresponding items are accessible:

```
| 'hydrology-evap'
| 'hydrology-glacier-melt'
| 'hydrology-iswe'
| 'hydrology-runoff'
| 'hydrology-sm'
| 'hydrology-snow-melt'
```


Then run ARDAC Explorer against the development API:

```
export SNAP_API_URL=https://development.earthmaps.io
npm run dev
```

Then enter a location (e.g, "Fairbanks") into any of these hydrology data x-ray items to load the charts, then experiment with selecting different models to verify that the charts react accordingly:

http://localhost:3000/item/hydrology-evap
http://localhost:3000/item/hydrology-glacier-melt
http://localhost:3000/item/hydrology-iswe
http://localhost:3000/item/hydrology-runoff
http://localhost:3000/item/hydrology-sm
http://localhost:3000/item/hydrology-snow-melt