### PR TITLE
Adds the CMIP6 Sea Ice and Snow items

### DIFF
--- a/components/Cmip6MonthlyChart.vue
+++ b/components/Cmip6MonthlyChart.vue
@@ -107,16 +107,30 @@ const buildChart = () => {
         values.push(value)
       })
 
-      traces.push({
-        x: config.years,
-        y: values,
-        mode: 'markers',
-        type: 'scatter',
-        name: config.label,
-        marker: {
-          symbol: config.symbol,
-        },
-      })
+      // Makes chart for sea ice concentration into a line chart
+      if (props.dataKey === 'siconc') {
+        traces.push({
+          x: config.years,
+          y: values,
+          mode: 'lines',
+          type: 'scatter',
+          name: config.label,
+          line: {
+            shape: 'spline',
+          },
+        })
+      } else {
+        traces.push({
+          x: config.years,
+          y: values,
+          mode: 'markers',
+          type: 'scatter',
+          name: config.label,
+          marker: {
+            symbol: config.symbol,
+          },
+        })
+      }
 
       allChartValues = allChartValues.concat(values)
     })

--- a/components/Cmip6MonthlyChart.vue
+++ b/components/Cmip6MonthlyChart.vue
@@ -116,7 +116,7 @@ const buildChart = () => {
           type: 'scatter',
           name: config.label,
           line: {
-            shape: 'spline',
+            shape: 'linear',
           },
         })
       } else {

--- a/components/Cmip6MonthlyChart.vue
+++ b/components/Cmip6MonthlyChart.vue
@@ -3,6 +3,7 @@ const props = defineProps<{
   label: string
   units?: string
   dataKey: string
+  chartType?: string
 }>()
 
 import type { Data } from 'plotly.js-dist-min'
@@ -108,7 +109,7 @@ const buildChart = () => {
       })
 
       // Makes chart for sea ice concentration into a line chart
-      if (props.dataKey === 'siconc') {
+      if (props.chartType === 'lines') {
         traces.push({
           x: config.years,
           y: values,

--- a/components/Cmip6MonthlyChartControls.vue
+++ b/components/Cmip6MonthlyChartControls.vue
@@ -11,9 +11,9 @@ const chartStore = useChartStore()
 
 const defaultScenario = 'ssp585'
 
-let modelInput = defineModel('model', { default: 'EC-Earth3-Veg' })
+const modelInput = defineModel('model', { default: 'EC-Earth3-Veg' })
 const scenarioInput = defineModel('scenario', { default: defaultScenario })
-let monthInput = defineModel('month', { default: '08' })
+const monthInput = defineModel('month', { default: '08' })
 
 if (props.defaultModel) {
   modelInput.value = props.defaultModel

--- a/components/Cmip6MonthlyChartControls.vue
+++ b/components/Cmip6MonthlyChartControls.vue
@@ -11,9 +11,9 @@ const chartStore = useChartStore()
 
 const defaultScenario = 'ssp585'
 
-const modelInput = defineModel('model', { default: 'EC-Earth3-Veg' })
+let modelInput = defineModel('model', { default: 'EC-Earth3-Veg' })
 const scenarioInput = defineModel('scenario', { default: defaultScenario })
-const monthInput = defineModel('month', { default: '08' })
+let monthInput = defineModel('month', { default: '08' })
 
 if (props.defaultModel) {
   modelInput.value = props.defaultModel
@@ -65,6 +65,39 @@ chartStore.labels = {
     '11': 'November',
     '12': 'December',
   },
+}
+
+// Sea ice concentration data is only available for some models.
+if (props.datasetKeys?.includes('siconc')) {
+  chartStore.labels = {
+    models: {
+      'HadGEM3-GC31-LL': 'HadGEM3-GC31-LL',
+      'HadGEM3-GC31-MM': 'HadGEM3-GC31-MM',
+      MIROC6: 'MIROC6',
+      'NorESM2-MM': 'NorESM2-MM',
+      TaiESM1: 'TaiESM1',
+    },
+    scenarios: {
+      ssp126: 'SSP1-2.6',
+      ssp245: 'SSP2-4.5',
+      ssp370: 'SSP3-7.0',
+      ssp585: 'SSP5-8.5',
+    },
+    months: {
+      '01': 'January',
+      '02': 'February',
+      '03': 'March',
+      '04': 'April',
+      '05': 'May',
+      '06': 'June',
+      '07': 'July',
+      '08': 'August',
+      '09': 'September',
+      '10': 'October',
+      '11': 'November',
+      '12': 'December',
+    },
+  }
 }
 
 // Some models do not have data for all scenarios. Use this function to react

--- a/components/Cmip6MonthlyChartControls.vue
+++ b/components/Cmip6MonthlyChartControls.vue
@@ -69,34 +69,17 @@ chartStore.labels = {
 
 // Sea ice concentration data is only available for some models.
 if (props.datasetKeys?.includes('siconc')) {
-  chartStore.labels = {
-    models: {
-      'HadGEM3-GC31-LL': 'HadGEM3-GC31-LL',
-      'HadGEM3-GC31-MM': 'HadGEM3-GC31-MM',
-      MIROC6: 'MIROC6',
-      'NorESM2-MM': 'NorESM2-MM',
-      TaiESM1: 'TaiESM1',
-    },
-    scenarios: {
-      ssp126: 'SSP1-2.6',
-      ssp245: 'SSP2-4.5',
-      ssp370: 'SSP3-7.0',
-      ssp585: 'SSP5-8.5',
-    },
-    months: {
-      '01': 'January',
-      '02': 'February',
-      '03': 'March',
-      '04': 'April',
-      '05': 'May',
-      '06': 'June',
-      '07': 'July',
-      '08': 'August',
-      '09': 'September',
-      '10': 'October',
-      '11': 'November',
-      '12': 'December',
-    },
+  if (props.datasetKeys?.includes('siconc')) {
+    chartStore.labels = {
+      ...chartStore.labels,
+      models: {
+        'HadGEM3-GC31-LL': 'HadGEM3-GC31-LL',
+        'HadGEM3-GC31-MM': 'HadGEM3-GC31-MM',
+        MIROC6: 'MIROC6',
+        'NorESM2-MM': 'NorESM2-MM',
+        TaiESM1: 'TaiESM1',
+      },
+    }
   }
 }
 

--- a/components/Gimme.vue
+++ b/components/Gimme.vue
@@ -138,8 +138,8 @@ onMounted(() => {
     // If it's an ocean type selector, choose the associated ocean pixel.
     if (props.ocean) {
       placesStore.latLng = {
-        lat: community.ocean_lati,
-        lng: community.ocean_long,
+        lat: community.ocean_lat1,
+        lng: community.ocean_lon1,
       }
     } else {
       placesStore.latLng = { lat: community.latitude, lng: community.longitude }

--- a/components/global/PrecipitationCmip6.vue
+++ b/components/global/PrecipitationCmip6.vue
@@ -134,8 +134,9 @@ onUnmounted(() => {
       <XrayIntroblurb resolution="100" unit="km" cmip="6" beta />
       <p class="mb-6">
         The map below shows modeled total precipitation for the month of August
-        using the EC-Earth3-Veg model at 25-year intervals from 1950–2000.
-        Intervals from 2025–2100 are based on the SSP5-8.5 emissions scenario.
+        using the EC-Earth3-Veg model at 25-year intervals from 1950&ndash;2000.
+        Intervals from 2025&ndash;2100 are based on the SSP5-8.5 emissions
+        scenario.
       </p>
 
       <MapBlock :mapId="mapId" crs="EPSG:3572" class="mb-6">

--- a/components/global/PrecipitationCmip6.vue
+++ b/components/global/PrecipitationCmip6.vue
@@ -134,7 +134,7 @@ onUnmounted(() => {
       <XrayIntroblurb resolution="100" unit="km" cmip="6" beta />
       <p class="mb-6">
         The map below shows modeled total precipitation for the month of August
-        using the EC-Earth3-Veg model at 25-year intervals from 1950&ndash;2000.
+        using the EC-Earth3-Veg model at 25-year intervals from 1950&ndash;2100.
         Intervals from 2025&ndash;2100 are based on the SSP5-8.5 emissions
         scenario.
       </p>

--- a/components/global/SeaIceCmip6.vue
+++ b/components/global/SeaIceCmip6.vue
@@ -165,7 +165,7 @@ mapStore.setLegendItems(mapId, legend)
         where you can download the data that is used to populate the chart.
       </p>
 
-      <Gimme />
+      <Gimme :bbox="[-180, 45, 180, 90]" ocean />
       <Cmip6MonthlyChartControls
         defaultModel="MIROC6"
         defaultMonth="03"

--- a/components/global/SeaIceCmip6.vue
+++ b/components/global/SeaIceCmip6.vue
@@ -15,6 +15,7 @@ const layers: MapLayer[] = [
     wmsLayerName: 'cmip6_monthly',
     style: 'ardac_siconc',
     legend: 'siconc',
+    default: true,
     rasdamanConfiguration: {
       dim_model: 7,
       dim_scenario: 0,
@@ -122,8 +123,9 @@ mapStore.setLegendItems(mapId, legend)
 </script>
 
 <template>
-  <section class="section">
+  <section class="section xray">
     <div class="content is-size-5">
+      <XrayIntroblurb resolution="100" unit="km" cmip="6" beta />
       <h3 class="title is-3">Sea Ice Concentration, CMIP6</h3>
       <p class="mb-6">
         The map below shows modeled sea ice concentration for the month of March
@@ -134,26 +136,14 @@ mapStore.setLegendItems(mapId, legend)
 
       <MapBlock :mapId="mapId" class="mb-6">
         <template v-slot:layers>
-          <MapLayer :mapId="mapId" :layer="layers[0]" default>
-            <template v-slot:title>{{ layers[0].title }}</template>
-          </MapLayer>
-          <MapLayer :mapId="mapId" :layer="layers[1]">
-            <template v-slot:title>{{ layers[1].title }}</template>
-          </MapLayer>
-          <MapLayer :mapId="mapId" :layer="layers[2]">
-            <template v-slot:title>{{ layers[2].title }}</template>
-          </MapLayer>
-          <MapLayer :mapId="mapId" :layer="layers[3]">
-            <template v-slot:title>{{ layers[3].title }}</template>
-          </MapLayer>
-          <MapLayer :mapId="mapId" :layer="layers[4]">
-            <template v-slot:title>{{ layers[4].title }}</template>
-          </MapLayer>
-          <MapLayer :mapId="mapId" :layer="layers[5]">
-            <template v-slot:title>{{ layers[5].title }}</template>
-          </MapLayer>
-          <MapLayer :mapId="mapId" :layer="layers[6]">
-            <template v-slot:title>{{ layers[6].title }}</template>
+          <MapLayer
+            v-for="layer in layers"
+            :mapId="mapId"
+            :layer="layer"
+            :key="layer.id"
+            :default="layer.default"
+          >
+            <template v-slot:title>{{ layer.title }}</template>
           </MapLayer>
         </template>
       </MapBlock>

--- a/components/global/SeaIceCmip6.vue
+++ b/components/global/SeaIceCmip6.vue
@@ -165,6 +165,7 @@ mapStore.setLegendItems(mapId, legend)
         label="Sea Ice Concentration"
         units="%"
         dataKey="siconc"
+        chartType="lines"
       />
 
       <div v-if="latLng && apiData" class="my-6">

--- a/components/global/SeaIceCmip6.vue
+++ b/components/global/SeaIceCmip6.vue
@@ -12,7 +12,7 @@ const layers: MapLayer[] = [
     id: 'siconc_cmip6_1950',
     title: 'March 1950, MIROC6',
     source: 'rasdaman',
-    wmsLayerName: 'cmip6_monthly_cryo_test',
+    wmsLayerName: 'cmip6_monthly',
     style: 'ardac_siconc',
     legend: 'siconc',
     rasdamanConfiguration: {
@@ -26,7 +26,7 @@ const layers: MapLayer[] = [
     id: 'siconc_cmip6_1975',
     title: 'March 1975, MIROC6',
     source: 'rasdaman',
-    wmsLayerName: 'cmip6_monthly_cryo_test',
+    wmsLayerName: 'cmip6_monthly',
     style: 'ardac_siconc',
     legend: 'siconc',
     rasdamanConfiguration: {
@@ -40,7 +40,7 @@ const layers: MapLayer[] = [
     id: 'siconc_cmip6_2000',
     title: 'March 2000, MIROC6',
     source: 'rasdaman',
-    wmsLayerName: 'cmip6_monthly_cryo_test',
+    wmsLayerName: 'cmip6_monthly',
     style: 'ardac_siconc',
     legend: 'siconc',
     rasdamanConfiguration: {
@@ -54,7 +54,7 @@ const layers: MapLayer[] = [
     id: 'siconc_cmip6_2025',
     title: 'March 2025, MIROC6',
     source: 'rasdaman',
-    wmsLayerName: 'cmip6_monthly_cryo_test',
+    wmsLayerName: 'cmip6_monthly',
     style: 'ardac_siconc',
     legend: 'siconc',
     rasdamanConfiguration: {
@@ -68,7 +68,7 @@ const layers: MapLayer[] = [
     id: 'siconc_cmip6_2050',
     title: 'March 2050, MIROC6',
     source: 'rasdaman',
-    wmsLayerName: 'cmip6_monthly_cryo_test',
+    wmsLayerName: 'cmip6_monthly',
     style: 'ardac_siconc',
     legend: 'siconc',
     rasdamanConfiguration: {
@@ -82,7 +82,7 @@ const layers: MapLayer[] = [
     id: 'siconc_cmip6_2075',
     title: 'March 2075, MIROC6',
     source: 'rasdaman',
-    wmsLayerName: 'cmip6_monthly_cryo_test',
+    wmsLayerName: 'cmip6_monthly',
     style: 'ardac_siconc',
     legend: 'siconc',
     rasdamanConfiguration: {
@@ -96,7 +96,7 @@ const layers: MapLayer[] = [
     id: 'siconc_cmip6_2100',
     title: 'March 2100, MIROC6',
     source: 'rasdaman',
-    wmsLayerName: 'cmip6_monthly_cryo_test',
+    wmsLayerName: 'cmip6_monthly',
     style: 'ardac_siconc',
     legend: 'siconc',
     rasdamanConfiguration: {
@@ -110,7 +110,6 @@ const layers: MapLayer[] = [
 
 const legend: Record<string, LegendItem[]> = {
   siconc: [
-    { color: '#f1eef6', label: 'Not Modeled' },
     { color: '#045a8d', label: '0&#37; &ndash; 70&#37;' },
     { color: '#2b8cbe', label: '70&#37; &ndash; 80&#37;' },
     { color: '#74a9cf', label: '80&#37; &ndash; 90&#37;' },

--- a/components/global/SeaIceCmip6.vue
+++ b/components/global/SeaIceCmip6.vue
@@ -129,7 +129,7 @@ mapStore.setLegendItems(mapId, legend)
       <h3 class="title is-3">Sea Ice Concentration, CMIP6</h3>
       <p class="mb-6">
         The map below shows modeled sea ice concentration for the month of March
-        using the EC-Earth3-Veg model at 25-year intervals from 1950&ndash;2000.
+        using the MIROC6 model at 25-year intervals from 1950&ndash;2100.
         Intervals from 2025&ndash;2100 are based on the SSP5-8.5 emissions
         scenario.
       </p>

--- a/components/global/SeaIceCmip6.vue
+++ b/components/global/SeaIceCmip6.vue
@@ -134,7 +134,7 @@ mapStore.setLegendItems(mapId, legend)
         scenario.
       </p>
 
-      <MapBlock :mapId="mapId" class="mb-6">
+      <MapBlock :mapId="mapId" crs="EPSG:3572" class="mb-6">
         <template v-slot:layers>
           <MapLayer
             v-for="layer in layers"

--- a/components/global/SeaIceCmip6.vue
+++ b/components/global/SeaIceCmip6.vue
@@ -1,0 +1,219 @@
+<script lang="ts" setup>
+const placesStore = usePlacesStore()
+const mapStore = useMapStore()
+const dataStore = useDataStore()
+const runtimeConfig = useRuntimeConfig()
+
+const apiData = computed<Record<string, any>>(() => dataStore.apiData)
+const latLng = computed<LatLngValue>(() => placesStore.latLng)
+
+const layers: MapLayer[] = [
+  {
+    id: 'siconc_cmip6_1950',
+    title: 'March 1950, MIROC6',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly_cryo_test',
+    style: 'ardac_siconc',
+    legend: 'siconc',
+    rasdamanConfiguration: {
+      dim_model: 7,
+      dim_scenario: 0,
+      time: '1950-03-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'siconc_cmip6_1975',
+    title: 'March 1975, MIROC6',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly_cryo_test',
+    style: 'ardac_siconc',
+    legend: 'siconc',
+    rasdamanConfiguration: {
+      dim_model: 7,
+      dim_scenario: 0,
+      time: '1975-03-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'siconc_cmip6_2000',
+    title: 'March 2000, MIROC6',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly_cryo_test',
+    style: 'ardac_siconc',
+    legend: 'siconc',
+    rasdamanConfiguration: {
+      dim_model: 7,
+      dim_scenario: 0,
+      time: '2000-03-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'siconc_cmip6_2025',
+    title: 'March 2025, MIROC6',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly_cryo_test',
+    style: 'ardac_siconc',
+    legend: 'siconc',
+    rasdamanConfiguration: {
+      dim_model: 7,
+      dim_scenario: 4,
+      time: '2025-03-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'siconc_cmip6_2050',
+    title: 'March 2050, MIROC6',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly_cryo_test',
+    style: 'ardac_siconc',
+    legend: 'siconc',
+    rasdamanConfiguration: {
+      dim_model: 7,
+      dim_scenario: 4,
+      time: '2050-03-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'siconc_cmip6_2075',
+    title: 'March 2075, MIROC6',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly_cryo_test',
+    style: 'ardac_siconc',
+    legend: 'siconc',
+    rasdamanConfiguration: {
+      dim_model: 7,
+      dim_scenario: 4,
+      time: '2075-03-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'siconc_cmip6_2100',
+    title: 'March 2100, MIROC6',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly_cryo_test',
+    style: 'ardac_siconc',
+    legend: 'siconc',
+    rasdamanConfiguration: {
+      dim_model: 7,
+      dim_scenario: 4,
+      time: '2100-03-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+]
+
+const legend: Record<string, LegendItem[]> = {
+  siconc: [
+    { color: '#f1eef6', label: 'Not Modeled' },
+    { color: '#045a8d', label: '0&#37; &ndash; 70&#37;' },
+    { color: '#2b8cbe', label: '70&#37; &ndash; 80&#37;' },
+    { color: '#74a9cf', label: '80&#37; &ndash; 90&#37;' },
+    { color: '#bdc9e1', label: '90&#37; &ndash; 100&#37;' },
+  ],
+}
+
+const mapId = 'sea_ice_cmip6'
+mapStore.setLegendItems(mapId, legend)
+</script>
+
+<template>
+  <section class="section">
+    <div class="content is-size-5">
+      <h3 class="title is-3">Sea Ice Concentration, CMIP6</h3>
+      <p class="mb-6">
+        The map below shows modeled sea ice concentration for the month of March
+        using the EC-Earth3-Veg model at 25-year intervals from 1950&ndash;2000.
+        Intervals from 2025&ndash;2100 are based on the SSP5-8.5 emissions
+        scenario.
+      </p>
+
+      <MapBlock :mapId="mapId" class="mb-6">
+        <template v-slot:layers>
+          <MapLayer :mapId="mapId" :layer="layers[0]" default>
+            <template v-slot:title>{{ layers[0].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[1]">
+            <template v-slot:title>{{ layers[1].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[2]">
+            <template v-slot:title>{{ layers[2].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[3]">
+            <template v-slot:title>{{ layers[3].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[4]">
+            <template v-slot:title>{{ layers[4].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[5]">
+            <template v-slot:title>{{ layers[5].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[6]">
+            <template v-slot:title>{{ layers[6].title }}</template>
+          </MapLayer>
+        </template>
+      </MapBlock>
+
+      <p>
+        Enter a location below to see a chart of the total monthly sea ice
+        concentration for a point location using the selected model, emissions
+        scenario, and month. After entering a location, links will be provided
+        where you can download the data that is used to populate the chart.
+      </p>
+
+      <Gimme />
+      <Cmip6MonthlyChartControls
+        defaultModel="MIROC6"
+        defaultMonth="03"
+        :datasetKeys="['siconc']"
+      />
+      <Cmip6MonthlyChart
+        label="Sea Ice Concentration"
+        units="%"
+        dataKey="siconc"
+      />
+
+      <div v-if="latLng && apiData" class="my-6">
+        <h4 class="title is-4">
+          Download CMIP6 sea ice concentration data for {{ latLng.lat }},
+          {{ latLng.lng }}
+        </h4>
+        <ul>
+          <li>
+            <a
+              :href="
+                runtimeConfig.public.apiUrl +
+                '/cmip6/point/' +
+                latLng.lat +
+                '/' +
+                latLng.lng +
+                '?vars=siconc&format=csv'
+              "
+              >Download as CSV</a
+            >
+          </li>
+          <li>
+            <a
+              :href="
+                runtimeConfig.public.apiUrl +
+                '/cmip6/point/' +
+                latLng.lat +
+                '/' +
+                latLng.lng +
+                '?vars=siconc'
+              "
+              >Download as JSON</a
+            >
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style lang="scss" scoped></style>

--- a/components/global/SnowCmip6.vue
+++ b/components/global/SnowCmip6.vue
@@ -310,7 +310,7 @@ mapStore.setLegendItems(mapId, legend)
         used to populate the chart.
       </p>
 
-      <Gimme />
+      <Gimme :bbox="[-180, 45, 180, 90]" />
       <Cmip6MonthlyChartControls
         defaultModel="MIROC6"
         defaultMonth="12"

--- a/components/global/SnowCmip6.vue
+++ b/components/global/SnowCmip6.vue
@@ -258,7 +258,7 @@ mapStore.setLegendItems(mapId, legend)
         from 2025&ndash;2100 are based on the SSP5-8.5 emissions scenario.
       </p>
 
-      <MapBlock :mapId="mapId" class="mb-6">
+      <MapBlock :mapId="mapId" crs="EPSG:3572" class="mb-6">
         <template v-slot:layers>
           <h4 class="title is-4 mb-3">March Precipitation as Snow</h4>
           <MapLayer

--- a/components/global/SnowCmip6.vue
+++ b/components/global/SnowCmip6.vue
@@ -1,0 +1,368 @@
+<script lang="ts" setup>
+const placesStore = usePlacesStore()
+const mapStore = useMapStore()
+const dataStore = useDataStore()
+const runtimeConfig = useRuntimeConfig()
+
+const apiData = computed<Record<string, any>>(() => dataStore.apiData)
+const latLng = computed<LatLngValue>(() => placesStore.latLng)
+
+const layers: MapLayer[] = [
+  {
+    id: 'prsn_cmip6_1950',
+    title: 'March 1950, MIROC6',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_prsn',
+    legend: 'prsn',
+    rasdamanConfiguration: {
+      dim_model: 7,
+      dim_scenario: 0,
+      time: '1950-03-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'prsn_cmip6_1975',
+    title: 'March 1975, MIROC6',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_prsn',
+    legend: 'prsn',
+    rasdamanConfiguration: {
+      dim_model: 7,
+      dim_scenario: 0,
+      time: '1975-03-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'prsn_cmip6_2000',
+    title: 'March 2000, MIROC6',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_prsn',
+    legend: 'prsn',
+    rasdamanConfiguration: {
+      dim_model: 7,
+      dim_scenario: 0,
+      time: '2000-03-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'prsn_cmip6_2025',
+    title: 'March 2025, MIROC6',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_prsn',
+    legend: 'prsn',
+    rasdamanConfiguration: {
+      dim_model: 7,
+      dim_scenario: 4,
+      time: '2025-03-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'prsn_cmip6_2050',
+    title: 'March 2050, MIROC6',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_prsn',
+    legend: 'prsn',
+    rasdamanConfiguration: {
+      dim_model: 7,
+      dim_scenario: 4,
+      time: '2050-03-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'prsn_cmip6_2075',
+    title: 'March 2075, MIROC6',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_prsn',
+    legend: 'prsn',
+    rasdamanConfiguration: {
+      dim_model: 7,
+      dim_scenario: 4,
+      time: '2075-03-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'prsn_cmip6_2100',
+    title: 'March 2100, MIROC6',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_prsn',
+    legend: 'prsn',
+    rasdamanConfiguration: {
+      dim_model: 7,
+      dim_scenario: 4,
+      time: '2100-03-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'swe_cmip6_1950',
+    title: 'March 1950, MIROC6',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_swe',
+    legend: 'swe',
+    rasdamanConfiguration: {
+      dim_model: 7,
+      dim_scenario: 0,
+      time: '1950-03-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'swe_cmip6_1975',
+    title: 'March 1975, MIROC6',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_swe',
+    legend: 'swe',
+    rasdamanConfiguration: {
+      dim_model: 7,
+      dim_scenario: 0,
+      time: '1975-03-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'swe_cmip6_2000',
+    title: 'March 2000, MIROC6',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_swe',
+    legend: 'swe',
+    rasdamanConfiguration: {
+      dim_model: 7,
+      dim_scenario: 0,
+      time: '2000-03-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'swe_cmip6_2025',
+    title: 'March 2025, MIROC6',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_swe',
+    legend: 'swe',
+    rasdamanConfiguration: {
+      dim_model: 7,
+      dim_scenario: 4,
+      time: '2025-03-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'swe_cmip6_2050',
+    title: 'March 2050, MIROC6',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_swe',
+    legend: 'swe',
+    rasdamanConfiguration: {
+      dim_model: 7,
+      dim_scenario: 4,
+      time: '2050-03-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'swe_cmip6_2075',
+    title: 'March 2075, MIROC6',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_swe',
+    legend: 'swe',
+    rasdamanConfiguration: {
+      dim_model: 7,
+      dim_scenario: 4,
+      time: '2075-03-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+  {
+    id: 'swe_cmip6_2100',
+    title: 'March 2100, MIROC6',
+    source: 'rasdaman',
+    wmsLayerName: 'cmip6_monthly',
+    style: 'ardac_swe',
+    legend: 'swe',
+    rasdamanConfiguration: {
+      dim_model: 7,
+      dim_scenario: 4,
+      time: '2100-03-15T12:00:00.000Z',
+    },
+    coastline: true,
+  },
+]
+
+const legend: Record<string, LegendItem[]> = {
+  prsn: [
+    {
+      color: '#edf8fbff',
+      label:
+        '&ge; 0 kg m&#8315;&sup2; s&#8315;&sup1;, &lt; 20 kg m&#8315;&sup2; s&#8315;&sup1;',
+    },
+    {
+      color: '#b2e2e2ff',
+      label:
+        '&ge; 20 kg m&#8315;&sup2; s&#8315;&sup1;, &lt; 40 kg m&#8315;&sup2; s&#8315;&sup1;',
+    },
+    {
+      color: '#66c2a4ff',
+      label:
+        '&ge; 40 kg m&#8315;&sup2; s&#8315;&sup1;, &lt; 60 kg m&#8315;&sup2; s&#8315;&sup1;',
+    },
+    {
+      color: '#2ca25fff',
+      label:
+        '&ge; 60 kg m&#8315;&sup2; s&#8315;&sup1;, &lt; 80 kg m&#8315;&sup2; s&#8315;&sup1;',
+    },
+    { color: '#006d2cff', label: '&ge; 80 kg m&#8315;&sup2; s&#8315;&sup1;' },
+  ],
+  swe: [
+    { color: '#edf8fbff', label: '&ge;0 mm, &lt;75 mm' },
+    { color: '#b2e2e2ff', label: '&ge;75 mm, &lt;150 mm' },
+    { color: '#66c2a4ff', label: '&ge;150 mm, &lt;225 mm' },
+    { color: '#2ca25fff', label: '&ge;225 mm, &lt;300 mm' },
+    { color: '#006d2cff', label: '&ge;300 mm' },
+  ],
+}
+
+const mapId = 'sea_ice_cmip6'
+mapStore.setLegendItems(mapId, legend)
+</script>
+
+<template>
+  <section class="section">
+    <div class="content is-size-5">
+      <h3 class="title is-3">Snow, CMIP6</h3>
+      <p class="mb-6">
+        The map below shows modeled snow variables for the month of March using
+        the MIROC6 model at 25-year intervals from 1950&ndash;2000. Intervals
+        from 2025&ndash;2100 are based on the SSP5-8.5 emissions scenario.
+      </p>
+
+      <MapBlock :mapId="mapId" class="mb-6">
+        <template v-slot:layers>
+          <h4 class="title is-4 mb-3">March Precipitation as Snow</h4>
+          <MapLayer :mapId="mapId" :layer="layers[0]" default>
+            <template v-slot:title>{{ layers[0].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[1]">
+            <template v-slot:title>{{ layers[1].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[2]">
+            <template v-slot:title>{{ layers[2].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[3]">
+            <template v-slot:title>{{ layers[3].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[4]">
+            <template v-slot:title>{{ layers[4].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[5]">
+            <template v-slot:title>{{ layers[5].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[6]">
+            <template v-slot:title>{{ layers[6].title }}</template>
+          </MapLayer>
+          <h4 class="title is-4 mb-3">March Snow Water Equivalent</h4>
+          <MapLayer :mapId="mapId" :layer="layers[7]">
+            <template v-slot:title>{{ layers[7].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[8]">
+            <template v-slot:title>{{ layers[8].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[9]">
+            <template v-slot:title>{{ layers[9].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[10]">
+            <template v-slot:title>{{ layers[10].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[11]">
+            <template v-slot:title>{{ layers[11].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[12]">
+            <template v-slot:title>{{ layers[12].title }}</template>
+          </MapLayer>
+          <MapLayer :mapId="mapId" :layer="layers[13]">
+            <template v-slot:title>{{ layers[13].title }}</template>
+          </MapLayer>
+        </template>
+      </MapBlock>
+
+      <p>
+        Enter a location below to see a chart of the monthly snow water
+        equivalent and precipitation as snow for a point location using the
+        selected model, emissions scenario, and month. After entering a
+        location, links will be provided where you can download the data that is
+        used to populate the chart.
+      </p>
+
+      <Gimme />
+      <Cmip6MonthlyChartControls
+        defaultModel="MIROC6"
+        defaultMonth="12"
+        :datasetKeys="['prsn', 'swe']"
+      />
+      <Cmip6MonthlyChart
+        label="Precipitation as Snow in kg m⁻² s⁻¹"
+        units="kg m⁻² s⁻¹"
+        dataKey="prsn"
+      />
+      <Cmip6MonthlyChart
+        label="Snow Water Equivalent in mm"
+        units="mm"
+        dataKey="swe"
+      />
+
+      <div v-if="latLng && apiData" class="my-6">
+        <h4 class="title is-4">
+          Download CMIP6 snow data for {{ latLng.lat }},
+          {{ latLng.lng }}
+        </h4>
+        <ul>
+          <li>
+            <a
+              :href="
+                runtimeConfig.public.apiUrl +
+                '/cmip6/point/' +
+                latLng.lat +
+                '/' +
+                latLng.lng +
+                '?vars=prsn,swe&format=csv'
+              "
+              >Download as CSV</a
+            >
+          </li>
+          <li>
+            <a
+              :href="
+                runtimeConfig.public.apiUrl +
+                '/cmip6/point/' +
+                latLng.lat +
+                '/' +
+                latLng.lng +
+                '?vars=prsn,swe'
+              "
+              >Download as JSON</a
+            >
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style lang="scss" scoped></style>

--- a/components/global/SnowCmip6.vue
+++ b/components/global/SnowCmip6.vue
@@ -301,6 +301,7 @@ mapStore.setLegendItems(mapId, legend)
         label="Precipitation as Snow in kg m⁻² s⁻¹"
         units="kg m⁻² s⁻¹"
         dataKey="prsn"
+        class="mb-5"
       />
       <Cmip6MonthlyChart
         label="Snow Water Equivalent in mm"

--- a/components/global/SnowCmip6.vue
+++ b/components/global/SnowCmip6.vue
@@ -270,7 +270,7 @@ mapStore.setLegendItems(mapId, legend)
           >
             <template v-slot:title>{{ layer.title }}</template>
           </MapLayer>
-          <h4 class="title is-4 mb-3">March Snow Water Equivalent</h4>
+          <h4 class="title is-4 mb-3">Snow Water Equivalent</h4>
           <MapLayer
             v-for="layer in swe_layers"
             :mapId="mapId"

--- a/components/global/SnowCmip6.vue
+++ b/components/global/SnowCmip6.vue
@@ -7,7 +7,7 @@ const runtimeConfig = useRuntimeConfig()
 const apiData = computed<Record<string, any>>(() => dataStore.apiData)
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
-const layers: MapLayer[] = [
+const prsn_layers: MapLayer[] = [
   {
     id: 'prsn_cmip6_1950',
     title: 'March 1950, MIROC6',
@@ -15,6 +15,7 @@ const layers: MapLayer[] = [
     wmsLayerName: 'cmip6_monthly',
     style: 'ardac_prsn',
     legend: 'prsn',
+    default: true,
     rasdamanConfiguration: {
       dim_model: 7,
       dim_scenario: 0,
@@ -106,6 +107,9 @@ const layers: MapLayer[] = [
     },
     coastline: true,
   },
+]
+
+const swe_layers: MapLayer[] = [
   {
     id: 'swe_cmip6_1950',
     title: 'March 1950, MIROC6',
@@ -244,8 +248,9 @@ mapStore.setLegendItems(mapId, legend)
 </script>
 
 <template>
-  <section class="section">
+  <section class="section xray">
     <div class="content is-size-5">
+      <XrayIntroblurb resolution="100" unit="km" cmip="6" beta />
       <h3 class="title is-3">Snow, CMIP6</h3>
       <p class="mb-6">
         The map below shows modeled snow variables for the month of March using
@@ -256,48 +261,24 @@ mapStore.setLegendItems(mapId, legend)
       <MapBlock :mapId="mapId" class="mb-6">
         <template v-slot:layers>
           <h4 class="title is-4 mb-3">March Precipitation as Snow</h4>
-          <MapLayer :mapId="mapId" :layer="layers[0]" default>
-            <template v-slot:title>{{ layers[0].title }}</template>
-          </MapLayer>
-          <MapLayer :mapId="mapId" :layer="layers[1]">
-            <template v-slot:title>{{ layers[1].title }}</template>
-          </MapLayer>
-          <MapLayer :mapId="mapId" :layer="layers[2]">
-            <template v-slot:title>{{ layers[2].title }}</template>
-          </MapLayer>
-          <MapLayer :mapId="mapId" :layer="layers[3]">
-            <template v-slot:title>{{ layers[3].title }}</template>
-          </MapLayer>
-          <MapLayer :mapId="mapId" :layer="layers[4]">
-            <template v-slot:title>{{ layers[4].title }}</template>
-          </MapLayer>
-          <MapLayer :mapId="mapId" :layer="layers[5]">
-            <template v-slot:title>{{ layers[5].title }}</template>
-          </MapLayer>
-          <MapLayer :mapId="mapId" :layer="layers[6]">
-            <template v-slot:title>{{ layers[6].title }}</template>
+          <MapLayer
+            v-for="layer in prsn_layers"
+            :mapId="mapId"
+            :layer="layer"
+            :key="layer.id"
+            :default="layer.default"
+          >
+            <template v-slot:title>{{ layer.title }}</template>
           </MapLayer>
           <h4 class="title is-4 mb-3">March Snow Water Equivalent</h4>
-          <MapLayer :mapId="mapId" :layer="layers[7]">
-            <template v-slot:title>{{ layers[7].title }}</template>
-          </MapLayer>
-          <MapLayer :mapId="mapId" :layer="layers[8]">
-            <template v-slot:title>{{ layers[8].title }}</template>
-          </MapLayer>
-          <MapLayer :mapId="mapId" :layer="layers[9]">
-            <template v-slot:title>{{ layers[9].title }}</template>
-          </MapLayer>
-          <MapLayer :mapId="mapId" :layer="layers[10]">
-            <template v-slot:title>{{ layers[10].title }}</template>
-          </MapLayer>
-          <MapLayer :mapId="mapId" :layer="layers[11]">
-            <template v-slot:title>{{ layers[11].title }}</template>
-          </MapLayer>
-          <MapLayer :mapId="mapId" :layer="layers[12]">
-            <template v-slot:title>{{ layers[12].title }}</template>
-          </MapLayer>
-          <MapLayer :mapId="mapId" :layer="layers[13]">
-            <template v-slot:title>{{ layers[13].title }}</template>
+          <MapLayer
+            v-for="layer in swe_layers"
+            :mapId="mapId"
+            :layer="layer"
+            :key="layer.id"
+            :default="layer.default"
+          >
+            <template v-slot:title>{{ layer.title }}</template>
           </MapLayer>
         </template>
       </MapBlock>

--- a/components/global/SnowCmip6.vue
+++ b/components/global/SnowCmip6.vue
@@ -254,7 +254,7 @@ mapStore.setLegendItems(mapId, legend)
       <h3 class="title is-3">Snow, CMIP6</h3>
       <p class="mb-6">
         The map below shows modeled snow variables for the month of March using
-        the MIROC6 model at 25-year intervals from 1950&ndash;2000. Intervals
+        the MIROC6 model at 25-year intervals from 1950&ndash;2100. Intervals
         from 2025&ndash;2100 are based on the SSP5-8.5 emissions scenario.
       </p>
 

--- a/components/global/SnowCmip6.vue
+++ b/components/global/SnowCmip6.vue
@@ -260,7 +260,7 @@ mapStore.setLegendItems(mapId, legend)
 
       <MapBlock :mapId="mapId" crs="EPSG:3572" class="mb-6">
         <template v-slot:layers>
-          <h4 class="title is-4 mb-3">March Precipitation as Snow</h4>
+          <h4 class="title is-4 mb-3">Precipitation as Snow</h4>
           <MapLayer
             v-for="layer in prsn_layers"
             :mapId="mapId"

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -98,7 +98,7 @@ export default defineNuxtConfig({
   runtimeConfig: {
     public: {
       geoserverUrl:
-        process.env.GEOSERVER_URL || 'https://gs.mapventure.org/geoserver/wms',
+        process.env.GEOSERVER_URL || 'https://gs.earthmaps.io/geoserver/wms',
       apiUrl: process.env.SNAP_API_URL || 'https://earthmaps.io',
       rasdamanUrl:
         process.env.RASDAMAN_URL || 'https://maps.earthmaps.io/rasdaman/ows',

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -25,8 +25,8 @@ interface Community {
   longitude: number
   type: string
   is_coastal?: number
-  ocean_lati?: number
-  ocean_long?: number
+  ocean_lat1?: number
+  ocean_lon1?: number
 }
 
 type CommunityValue = Community | undefined


### PR DESCRIPTION
This PR adds the Sea Ice and Snow items to ARDAC at:

http://localhost:3000/item/sea-ice-cmip6
http://localhost:3000/item/snow-cmip6

This includes the pan-arctic maps, Xray blurb, charts, and the ability to get both CSVs and JSONs for each of the datasets. 

Try experimenting with a few different places to get different charts and make sure that all of the maps are working as expected.