### PR TITLE
Fix year range in intro text for CMIP6 Evaporation item

### DIFF
--- a/components/global/EvaporationCmip6.vue
+++ b/components/global/EvaporationCmip6.vue
@@ -146,7 +146,7 @@ onUnmounted(() => {
       <XrayIntroblurb resolution="100" unit="km" cmip="6" beta />
       <p class="mb-6">
         The map below shows modeled total evaporation for the month of August
-        using the EC-Earth3-Veg model at 25-year intervals from 1950–2000.
+        using the EC-Earth3-Veg model at 25-year intervals from 1950–2100.
         Intervals from 2025–2100 are based on the SSP5-8.5 emissions scenario.
       </p>
 


### PR DESCRIPTION
I noticed while reviewing PR #195 that I had made a mistake months ago in the intro text for some CMIP6 items, claiming that map layers were shown for "25-year intervals from 1950–2000", when it should say "25-year intervals from 1950–2100". All affected CMIP6 data x-ray items will be fixed in #195, except for Evaporation, which is unrelated to PR #195, but fixed here. Self-merging because this is a trivial change.