### PR TITLE
Fix place selector BBOX for CMIP6-based items

### DIFF
--- a/components/global/EvaporationCmip6.vue
+++ b/components/global/EvaporationCmip6.vue
@@ -183,7 +183,7 @@ onUnmounted(() => {
         the data that is used to populate the chart.
       </p>
 
-      <Gimme />
+      <Gimme :bbox="[-180, 50, 180, 90]" />
       <Cmip6MonthlyChartControls defaultMonth="08" :datasetKeys="['evspsbl']" />
       <Cmip6MonthlyChart
         label="Evaporation"

--- a/components/global/IndicatorDwCmip6.vue
+++ b/components/global/IndicatorDwCmip6.vue
@@ -58,7 +58,7 @@ mapStore.setLegendItems(mapId, legend)
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Deep Winter Days, CMIP6</h3>
-      <XrayIntroblurb resolution="100" unit="km" cmip="6" beta/>
+      <XrayIntroblurb resolution="100" unit="km" cmip="6" beta />
       <p class="mb-6">
         Deep winter days are the number of days per year that are below
         -22&deg;F. The map below shows the 30-year mean of CMIP6 deep winter
@@ -91,7 +91,7 @@ mapStore.setLegendItems(mapId, legend)
         where you can download the data that is used to populate the chart.
       </p>
 
-      <Gimme />
+      <Gimme :bbox="[-180, 50, 180, 90]" />
       <IndicatorsCmip6ChartControls />
       <IndicatorsCmip6Chart label="Deep winter days" dataKey="dw" />
 

--- a/components/global/IndicatorFtcCmip6.vue
+++ b/components/global/IndicatorFtcCmip6.vue
@@ -92,7 +92,7 @@ mapStore.setLegendItems(mapId, legend)
         where you can download the data that is used to populate the chart.
       </p>
 
-      <Gimme />
+      <Gimme :bbox="[-180, 50, 180, 90]" />
       <IndicatorsCmip6ChartControls />
       <IndicatorsCmip6Chart
         label="Freeze/thaw cycle"

--- a/components/global/IndicatorRx1dayCmip6.vue
+++ b/components/global/IndicatorRx1dayCmip6.vue
@@ -91,7 +91,7 @@ mapStore.setLegendItems(mapId, legend)
         populate the chart.
       </p>
 
-      <Gimme />
+      <Gimme :bbox="[-180, 50, 180, 90]" />
       <IndicatorsCmip6ChartControls />
       <IndicatorsCmip6Chart
         label="Maximum 1-day precipitation"

--- a/components/global/IndicatorSuCmip6.vue
+++ b/components/global/IndicatorSuCmip6.vue
@@ -90,7 +90,7 @@ mapStore.setLegendItems(mapId, legend)
         where you can download the data that is used to populate the chart.
       </p>
 
-      <Gimme />
+      <Gimme :bbox="[-180, 50, 180, 90]" />
       <IndicatorsCmip6ChartControls />
       <IndicatorsCmip6Chart label="Summer days" dataKey="su" />
 

--- a/components/global/OceanographyCmip6.vue
+++ b/components/global/OceanographyCmip6.vue
@@ -136,7 +136,7 @@ onUnmounted(() => {
         charts.
       </p>
 
-      <Gimme />
+      <Gimme :bbox="[-180, 50, 180, 90]" />
       <Cmip6MonthlyChartControls
         defaultMonth="08"
         :datasetKeys="['psl', 'ts']"

--- a/components/global/PrecipitationCmip6.vue
+++ b/components/global/PrecipitationCmip6.vue
@@ -159,7 +159,7 @@ onUnmounted(() => {
         download the data that is used to populate the chart.
       </p>
 
-      <Gimme />
+      <Gimme :bbox="[-180, 50, 180, 90]" />
       <Cmip6MonthlyChartControls defaultMonth="08" :datasetKeys="['pr']" />
       <Cmip6MonthlyChart label="Precipitation" units="㎜" dataKey="pr" />
 

--- a/components/global/SolarRadiationCloudCoverCmip6.vue
+++ b/components/global/SolarRadiationCloudCoverCmip6.vue
@@ -204,7 +204,7 @@ onUnmounted(() => {
         used to populate the charts.
       </p>
 
-      <Gimme />
+      <Gimme :bbox="[-180, 50, 180, 90]" />
       <Cmip6MonthlyChartControls
         defaultModel="HadGEM3-GC31-MM"
         defaultMonth="08"

--- a/components/global/TemperatureCmip6.vue
+++ b/components/global/TemperatureCmip6.vue
@@ -171,7 +171,7 @@ onUnmounted(() => {
         download the data that is used to populate the charts.
       </p>
 
-      <Gimme />
+      <Gimme :bbox="[-180, 50, 180, 90]" />
       <Cmip6MonthlyChartControls
         defaultModel="GFDL-ESM4"
         defaultMonth="07"

--- a/components/global/WindCmip6.vue
+++ b/components/global/WindCmip6.vue
@@ -185,7 +185,7 @@ onUnmounted(() => {
         can download the data that is used to populate the charts.
       </p>
 
-      <Gimme />
+      <Gimme :bbox="[-180, 50, 180, 90]" />
       <Cmip6MonthlyChartControls
         defaultMonth="08"
         :datasetKeys="['sfcWind', 'uas', 'vas']"


### PR DESCRIPTION
This PR fixes the place selector BBOX for all CMIP6-based items by passing the `Gimme` component a custom `bbox` property of `[-180, 50, 180, 90]`. The actual coverage extent in Rasdaman is slightly offset from these coordinates (`[-180.625, 49.94764397905759464285714286, 179.375, 90.47120418848167535714285714]`), but the `parse-dms` module doesn't seem to play well with longitudes like `-180.5`, so I'm keeping it simple for now to avoid client-side surprises later. I already tested some international queries for each affected CMIP6 monthly and CMIP6 indicator item this impacts, and the code is trivial enough, so I'm self-merging.