### PR TITLE
Update Evaporation unit scale to remove µ

### DIFF
--- a/components/Cmip6MonthlyChart.vue
+++ b/components/Cmip6MonthlyChart.vue
@@ -4,10 +4,18 @@ const props = defineProps<{
   units?: string
   dataKey: string
   chartType?: string
+  multiplier?: number
 }>()
 
 import type { Data } from 'plotly.js-dist-min'
 import { isProxy, toRaw } from 'vue'
+
+// Multiplier is an optional prop that can be used to change the scale of units
+// during chart population.
+let multiplier = 1
+if (props.multiplier) {
+  multiplier = props.multiplier
+}
 
 const { $Plotly, $_ } = useNuxtApp()
 const dataStore = useDataStore()
@@ -36,7 +44,7 @@ const monthMinMax = (values: any, month: string, dataKey: string) => {
         let last2 = key.slice(-2)
         if (last2 == month) {
           let typed = value as any
-          monthValues.push(typed[dataKey])
+          monthValues.push(typed[dataKey] * multiplier)
         }
       })
     })
@@ -105,7 +113,7 @@ const buildChart = () => {
 
         let yearMonthData = chartData[model][scenario][yearMonth]
         let value = yearMonthData[props.dataKey]
-        values.push(value)
+        values.push(value * multiplier)
       })
 
       // Makes chart for sea ice concentration into a line chart

--- a/components/global/EvaporationCmip6.vue
+++ b/components/global/EvaporationCmip6.vue
@@ -110,24 +110,36 @@ const layers: MapLayer[] = [
 
 const legend: Record<string, LegendItem[]> = {
   evspsbl: [
-    { color: '#538b69', label: '&lt;0µ kg/m<sup>2</sup>/s' },
+    {
+      color: '#538b69',
+      label:
+        '&lt;0 (1 &times; 10<sup>-6</sup>&nbsp;kg m<sup>-2</sup>&nbsp;s<sup>-1</sup>)',
+    },
     {
       color: '#6eb47e',
-      label: '&ge;0µ kg/m<sup>2</sup>/s, &lt;10µ kg/m<sup>2</sup>/s',
+      label:
+        '&ge;0, &lt;10 (1 &times; 10<sup>-6</sup>&nbsp;kg m<sup>-2</sup>&nbsp;s<sup>-1</sup>)',
     },
     {
       color: '#98cd97',
-      label: '&ge;10µ kg/m<sup>2</sup>/s, &lt;20µ kg/m<sup>2</sup>/s',
+      label:
+        '&ge;10, &lt;20 (1 &times; 10<sup>-6</sup>&nbsp;kg m<sup>-2</sup>&nbsp;s<sup>-1</sup>)',
     },
     {
       color: '#bbdea6',
-      label: '&ge;20µ kg/m<sup>2</sup>/s, &lt;30µ kg/m<sup>2</sup>/s',
+      label:
+        '&ge;20, &lt;30 (1 &times; 10<sup>-6</sup>&nbsp;kg m<sup>-2</sup>&nbsp;s<sup>-1</sup>)',
     },
     {
       color: '#dbebb5',
-      label: '&ge;30µ kg/m<sup>2</sup>/s, &lt;40µ kg/m<sup>2</sup>/s',
+      label:
+        '&ge;30, &lt;40, (1 &times; 10<sup>-6</sup>&nbsp;kg m<sup>-2</sup>&nbsp;s<sup>-1</sup>)',
     },
-    { color: '#f5f5d1', label: '&ge;40µ kg/m<sup>2</sup>/s' },
+    {
+      color: '#f5f5d1',
+      label:
+        '&ge;40 (1 &times; 10<sup>-6</sup>&nbsp;kg m<sup>-2</sup>&nbsp;s<sup>-1</sup>)',
+    },
   ],
 }
 
@@ -187,8 +199,9 @@ onUnmounted(() => {
       <Cmip6MonthlyChartControls defaultMonth="08" :datasetKeys="['evspsbl']" />
       <Cmip6MonthlyChart
         label="Evaporation"
-        units="kg/m<sup>2</sup>/s"
+        units="1 × 10<sup>-6</sup> kg m<sup>-2</sup> s<sup>-1</sup>"
         dataKey="evspsbl"
+        :multiplier="1000000"
       />
 
       <div v-if="latLng && apiData" class="my-6">


### PR DESCRIPTION
This PR modifies the following parts of the CMIP6 Evaporation data x-ray item to deal with tiny values better, removing the need to use the `µ` (one millionth) character:

- The map legend
- Chart y-axis label, y-axis tick marks, and hover text

For the map legend, it's sufficient to simply remove the `µ` character and change the units to "1 × 10⁻⁶ kg m⁻² s⁻¹", since `10⁻⁶` communicates that values are of the "one millionth" scale. No changes were needed to the WMS color maps or anything.

For the chart, the y-axis label was updated to use "1 × 10⁻⁶ kg m⁻² s⁻¹" for the units, but I also needed to multiply the values by 1,000,000 to remove the `µ` y-axis tick labels and hovertext values. This was implemented as an optional `multiplier` prop that can be passed into `Cmip6MonthlyChart.vue`, so we can reuse this for other variables if we ever have the need.

To test, look at the CMIP6 Evaporation data x-ray item and confirm that the map legend & charts make sense:
http://localhost:3000/item/evaporation-cmip6
