### PR TITLE
Removes the duplicated units shown in the title and Y-axis of the CMIP6 snow graphs.

### DIFF
--- a/components/global/SnowCmip6.vue
+++ b/components/global/SnowCmip6.vue
@@ -298,13 +298,13 @@ mapStore.setLegendItems(mapId, legend)
         :datasetKeys="['prsn', 'swe']"
       />
       <Cmip6MonthlyChart
-        label="Precipitation as Snow in kg m⁻² s⁻¹"
+        label="Precipitation as Snow"
         units="kg m⁻² s⁻¹"
         dataKey="prsn"
         class="mb-5"
       />
       <Cmip6MonthlyChart
-        label="Snow Water Equivalent in mm"
+        label="Snow Water Equivalent"
         units="mm"
         dataKey="swe"
       />


### PR DESCRIPTION
This PR simply removes the duplicated units shown in the CMIP6 snow graphs.

Closes #210 