### PR TITLE
Disable community queries for CMIP6 Sea Ice item and explain why to users

### DIFF
--- a/components/global/SeaIceCmip6.vue
+++ b/components/global/SeaIceCmip6.vue
@@ -155,7 +155,7 @@ mapStore.setLegendItems(mapId, legend)
         where you can download the data that is used to populate the chart.
       </p>
 
-      <Gimme :bbox="[-180, 45, 180, 90]" ocean />
+      <Gimme :bbox="[-180, 45, 180, 90]" ocean :communitiesEnabled="false" />
       <Cmip6MonthlyChartControls
         defaultModel="MIROC6"
         defaultMonth="03"

--- a/components/global/SeaIceCmip6.vue
+++ b/components/global/SeaIceCmip6.vue
@@ -155,6 +155,11 @@ mapStore.setLegendItems(mapId, legend)
         where you can download the data that is used to populate the chart.
       </p>
 
+      <p>
+        Coastal community queries are not supported due to the coarse resolution
+        of this dataset.
+      </p>
+
       <Gimme :bbox="[-180, 45, 180, 90]" ocean :communitiesEnabled="false" />
       <Cmip6MonthlyChartControls
         defaultModel="MIROC6"


### PR DESCRIPTION
Closes #211.

This PR disables community queries on the CMIP6 Sea Ice item by adding a new `communitiesEnabled` prop to the `Gimme` component that, when set to `false`, disables communities entirely and adjusts user prompts and placeholder text accordingly.

Specific information about why communities are disabled for the CMIP6 Sea Ice item has been added to the `SeaIceCmip6.vue` directly. Just a short blurb that says:

> Coastal community queries are not supported due to the coarse resolution of this dataset.

To test, compare the production vs. local versions of this ARDAC item to see the differences:

http://localhost:3000/item/sea-ice-cmip6
https://arcticdatascience.org/item/sea-ice-cmip6