### PR TITLE
Make communitiesEnabled an optional component prop

### DIFF
--- a/components/Gimme.vue
+++ b/components/Gimme.vue
@@ -5,7 +5,7 @@ interface Props {
   bbox?: number[]
   extent?: Extent
   ocean?: boolean
-  communitiesEnabled: boolean
+  communitiesEnabled?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {


### PR DESCRIPTION
I realized while poking around ARDAC Explorer locally that I neglected to make `communitiesEnabled` an optional prop in PR #214. Everything works as intended regardless because `communitiesEnabled` is immediately set to a default value if not set, but this fixes a JavaScript warning in the console. This is a very trivial change, so I am going to self-merge this.