### PR TITLE
Revamp README with S3 setup and deploy instructions, CloudFront invalidation, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,85 @@
 # 🥗 ARDAC Explorer
 
-## Setup, dev, release
+## Initial setup
+
+### Install dependencies
+
+Install nvm on your workstation if you have not already:
+
+https://github.com/nvm-sh/nvm
+
+Then run:
 
 ```bash
-nvm use lts/hydrogen
-npm install
-npm run dev
+$ nvm use lts/hydrogen
+$ npm install
+```
+
+### Set environment variables if necessary
+
+The following environment variables can be set to change the API and map service
+endpoints:
+
+| Environment variable | Default                                |
+| -------------------- | -------------------------------------- |
+| GEOSERVER_URL        | https://gs.earthmaps.io/geoserver/wms  |
+| RASDAMAN_URL         | https://maps.earthmaps.io/rasdaman/ows |
+| SNAP_API_URL         | https://earthmaps.io                   |
+
+### Enable website hosting on the AWS S3 bucket:
+
+**_The following command should be run only during the initial setup of the S3
+bucket. Do not run this command again or it will wipe out the S3 website
+redirection rules._**
+
+```
+aws s3 website s3://arcticdatascience.org/ --index-document index.html --error-document index.html
+```
+
+### Add website redirection rules to S3 bucket
+
+Website redirection rules need to be added to the S3 bucket for data to hydrate
+properly when a report is referenced directly by its URL (permalink).
+
+From the AWS web interface for the S3 bucket, go to:
+
+Properties → Static website hosting → Edit
+
+In the "Redirection rules" text area, add the following:
+
+```
+[
+    {
+        "Condition": {
+            "HttpErrorCodeReturnedEquals": "404"
+        },
+        "Redirect": {
+            "HostName": "arcticdatascience.org",
+            "Protocol": "http",
+            "ReplaceKeyPrefixWith": "#!/"
+        }
+    },
+    {
+        "Condition": {
+            "HttpErrorCodeReturnedEquals": "403"
+        },
+        "Redirect": {
+            "HostName": "arcticdatascience.org",
+            "Protocol": "http",
+            "ReplaceKeyPrefixWith": "#!/"
+        }
+    }
+]
+```
+
+Code in `app.vue` catches and routes these redirects into fully hydrated report pages.
+
+# Production
+
 npm run build # release
 npm run preview # preview the release
-```
+
+````
 
 ### Adding a new item
 
@@ -35,38 +106,38 @@ The item is now available for use in static layouts and will be included in any 
 
 <!-- headline, blurb, photo (if present), don't show tags -->
 <ItemTextPicture slug="indicator-dw" />
-```
+````
 
-To build the actual content for the item, add a Vue component in `components/global` named according to the slug pattern in CamelCase, i.e. `map-permafrost` would become `MapPermafrost`.  From the command line in the root of the project directory:
+To build the actual content for the item, add a Vue component in `components/global` named according to the slug pattern in CamelCase, i.e. `map-permafrost` would become `MapPermafrost`. From the command line in the root of the project directory:
 
 ```bash
 npx nuxi add component global/MapPermafrost
 ```
 
-...which will add a Vue SFC file in the right place.  Now, that component can be accessed by clicking on the item you just created.
+...which will add a Vue SFC file in the right place. Now, that component can be accessed by clicking on the item you just created.
 
-#### Connecting people / bios 
+#### Connecting people / bios
 
-When adding an item, consider if you should tag a person with the bio brief.  The guidelines are approximate, but consider doing this when:
+When adding an item, consider if you should tag a person with the bio brief. The guidelines are approximate, but consider doing this when:
 
- * It's a narrative story item
- * It's a new thing
- * The people you'd tag created the data or tech.  (If SNAP techs just do QA/QC and ingest/prep, we would not tag them; same for programmers who worked on features).  
+- It's a narrative story item
+- It's a new thing
+- The people you'd tag created the data or tech. (If SNAP techs just do QA/QC and ingest/prep, we would not tag them; same for programmers who worked on features).
 
- Use the `Bios` component, for example,
+Use the `Bios` component, for example,
 
- `<Bios :people="['Hajo Eicken', 'Scott Rupp']" />`
+`<Bios :people="['Hajo Eicken', 'Scott Rupp']" />`
 
 When adding someone new:
 
- * add an image to `/public/images/people`
- * add them to the `types/people.d.ts`
- * add the bio itself in `assets/bios.ts`
- * add the person to the `/people` page
+- add an image to `/public/images/people`
+- add them to the `types/people.d.ts`
+- add the bio itself in `assets/bios.ts`
+- add the person to the `/people` page
 
 #### Converting Jupyter notebooks to items
 
-Follow the pattern used in the `global/NotebookPermObsTemp` component.  To transform the HTML before copy/pasting it into the slot, activate a Conda environment with Jupyter and `nbconvert` and `tidy` (probably already installed in MacOS) then:
+Follow the pattern used in the `global/NotebookPermObsTemp` component. To transform the HTML before copy/pasting it into the slot, activate a Conda environment with Jupyter and `nbconvert` and `tidy` (probably already installed in MacOS) then:
 
 ```bash
 jupyter nbconvert --to html --template basic notebook.ipynb
@@ -74,4 +145,4 @@ tidy -i -m notebook.html
 sed -i '' 's/class\=\"input\"//' notebook.html
 ```
 
-This does a bit of cleanup and removes one class that will clash with Bulma.  Finally, copy paste everything in the `<body>` tag of the cleaned HTML into the `<slot>` in the `NotebookTemplate` component.
+This does a bit of cleanup and removes one class that will clash with Bulma. Finally, copy paste everything in the `<body>` tag of the cleaned HTML into the `<slot>` in the `NotebookTemplate` component.


### PR DESCRIPTION
Closes #203.

This PR revamps the README with information about how to configure the S3 bucket, how to build and deploy the webapp to the S3 bucket, invalidate CloudFront, etc. I've also added some additional information about installing NPM dependencies, what environment variables can be set, etc. to more closely match our README for Northern Climate Reports.