### PR TITLE
Load Gimme component lazily to fix long pauses on page load

### DIFF
--- a/components/DegreeDaysChart.vue
+++ b/components/DegreeDaysChart.vue
@@ -227,7 +227,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <Gimme extent="mizukami" />
+  <GimmeLoader extent="mizukami" />
   <div id="chart"></div>
 </template>
 

--- a/components/Gimme.vue
+++ b/components/Gimme.vue
@@ -1,19 +1,12 @@
 <script lang="ts" setup>
 // bbox order is
 // [ lower-left lng, lower-left lat, upper-right lng, upper-right lat ]
-interface Props {
-  bbox?: number[]
-  extent?: Extent
-  ocean?: boolean
-  communitiesEnabled?: boolean
-}
-
-const props = withDefaults(defineProps<Props>(), {
-  bbox: () => [-179.1506, 51.229, -129.9795, 71.3526],
-  extent: null,
-  ocean: false,
-  communitiesEnabled: true,
-})
+const props = defineProps<{
+  bbox: number[]
+  extent: Extent
+  ocean: boolean
+  communitiesEnabled: boolean
+}>()
 
 let bbox = props.bbox
 let extent = props.extent
@@ -171,6 +164,8 @@ onMounted(() => {
     }
     selectedCommunityName.value += ', ' + community.country
   })
+
+  placesStore.gimmeLoaded = true
 })
 
 const withinExtent = (lat: number, lng: number) => {

--- a/components/GimmeLoader.vue
+++ b/components/GimmeLoader.vue
@@ -1,0 +1,31 @@
+<script lang="ts" setup>
+// bbox order is
+// [ lower-left lng, lower-left lat, upper-right lng, upper-right lat ]
+interface Props {
+  bbox?: number[]
+  extent?: Extent
+  ocean?: boolean
+  communitiesEnabled?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  bbox: () => [-179.1506, 51.229, -129.9795, 71.3526],
+  extent: null,
+  ocean: false,
+  communitiesEnabled: true,
+})
+
+const placesStore = usePlacesStore()
+const isDocumentLoaded = ref(false)
+
+onMounted(() => {
+  isDocumentLoaded.value = true
+})
+</script>
+
+<template>
+  <div v-if="isDocumentLoaded">
+    <div v-if="!placesStore.gimmeLoaded" class="loader"></div>
+    <Gimme v-bind="props" />
+  </div>
+</template>

--- a/components/IndicatorsChart.vue
+++ b/components/IndicatorsChart.vue
@@ -211,7 +211,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <Gimme extent="mizukami" />
+  <GimmeLoader extent="mizukami" />
   <div v-if="latLng && apiData">
     <div class="control mb-5">
       <label class="radio mr-3">

--- a/components/global/AlfrescoFlammability.vue
+++ b/components/global/AlfrescoFlammability.vue
@@ -208,7 +208,13 @@ onUnmounted(() => {
 
       <MapBlock :mapId="mapId" class="mb-6">
         <template v-slot:layers>
-          <MapLayer v-for="layer in layers" :mapId="mapId" :layer="layer" :key="layer.id" :default="layer.default">
+          <MapLayer
+            v-for="layer in layers"
+            :mapId="mapId"
+            :layer="layer"
+            :key="layer.id"
+            :default="layer.default"
+          >
             <template v-slot:title>{{ layer.title }}</template>
           </MapLayer>
         </template>
@@ -228,7 +234,7 @@ onUnmounted(() => {
       </p>
 
       <!-- HUC-12 API summaries return data only for Alaska, not Canada -->
-      <Gimme extent="blockyAlaska" />
+      <GimmeLoader extent="blockyAlaska" />
 
       <div v-if="latLng && apiData">
         <div class="chart-input">

--- a/components/global/AlfrescoVegetation.vue
+++ b/components/global/AlfrescoVegetation.vue
@@ -241,7 +241,7 @@ onUnmounted(() => {
       </p>
 
       <!-- HUC-12 API summaries return data only for Alaska, not Canada -->
-      <Gimme extent="blockyAlaska" />
+      <GimmeLoader extent="blockyAlaska" />
 
       <div v-if="latLng && apiData">
         <div class="chart-input">

--- a/components/global/ClimateBeetleProtection.vue
+++ b/components/global/ClimateBeetleProtection.vue
@@ -133,7 +133,7 @@ onUnmounted(() => {
         download the data that is used to populate the table.
       </p>
 
-      <Gimme extent="blockyAlaska" />
+      <GimmeLoader extent="blockyAlaska" />
 
       <div v-if="latLng && apiData">
         <div class="parameter">

--- a/components/global/Elevation.vue
+++ b/components/global/Elevation.vue
@@ -58,7 +58,7 @@ onUnmounted(() => {
   <section class="section">
     <div class="content is-size-5">
       <h3 class="title is-3">Elevation</h3>
-      <XrayIntroblurb resolution="1" unit="km"/>
+      <XrayIntroblurb resolution="1" unit="km" />
       <p class="mb-6">
         The map below shows minimum, mean, and maximum elevation at a resolution
         of 1km:
@@ -85,7 +85,7 @@ onUnmounted(() => {
         populate the table.
       </p>
 
-      <Gimme extent="elevation" class="mb-5" />
+      <GimmeLoader extent="elevation" class="mb-5" />
 
       <div v-if="latLng && apiData">
         <h4 class="title is-4">

--- a/components/global/EvaporationCmip6.vue
+++ b/components/global/EvaporationCmip6.vue
@@ -195,7 +195,7 @@ onUnmounted(() => {
         the data that is used to populate the chart.
       </p>
 
-      <Gimme :bbox="[-180, 50, 180, 90]" />
+      <GimmeLoader :bbox="[-180, 50, 180, 90]" />
       <Cmip6MonthlyChartControls defaultMonth="08" :datasetKeys="['evspsbl']" />
       <Cmip6MonthlyChart
         label="Evaporation"

--- a/components/global/HydrologyEvap.vue
+++ b/components/global/HydrologyEvap.vue
@@ -59,7 +59,7 @@ onUnmounted(() => {
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Evapotranspiration</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         The map below shows the 30-year mean annual evapotranspiration for three
         eras using the CanESM2 model under the RCP 8.5 emissions scenario.
@@ -86,7 +86,7 @@ onUnmounted(() => {
         where you can download the data that is used to populate the chart.
       </p>
 
-      <Gimme extent="mizukami" />
+      <GimmeLoader extent="mizukami" />
       <HydrologyChartControls />
       <HydrologyChart label="Evapotranspiration" units="㎜" dataKey="evap" />
 

--- a/components/global/HydrologyGlacierMelt.vue
+++ b/components/global/HydrologyGlacierMelt.vue
@@ -59,7 +59,7 @@ onUnmounted(() => {
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Glacier Melt</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         The map below shows the 30-year mean annual glacier melt for three eras
         using the CanESM2 model under the RCP 8.5 emissions scenario.
@@ -86,7 +86,7 @@ onUnmounted(() => {
         where you can download the data that is used to populate the chart.
       </p>
 
-      <Gimme extent="mizukami" />
+      <GimmeLoader extent="mizukami" />
       <HydrologyChartControls />
       <HydrologyChart label="Glacier melt" units="㎜" dataKey="glacier_melt" />
 

--- a/components/global/HydrologyIswe.vue
+++ b/components/global/HydrologyIswe.vue
@@ -93,7 +93,7 @@ onUnmounted(() => {
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Ice/Snow Water Equivalent</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         The map below shows the 30-year mean monthly ice/snow water equivalent
         for three eras using the CanESM2 model under the RCP 8.5 emissions
@@ -131,7 +131,7 @@ onUnmounted(() => {
         charts.
       </p>
 
-      <Gimme extent="mizukami" />
+      <GimmeLoader extent="mizukami" />
       <HydrologyChartControls />
       <HydrologyChart
         label="Ice water equivalent"

--- a/components/global/HydrologyRunoff.vue
+++ b/components/global/HydrologyRunoff.vue
@@ -59,7 +59,7 @@ onUnmounted(() => {
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Runoff</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         The map below shows the 30-year mean annual runoff for three eras using
         the CanESM2 model under the RCP 8.5 emissions scenario.
@@ -86,7 +86,7 @@ onUnmounted(() => {
         download the data that is used to populate the chart.
       </p>
 
-      <Gimme extent="mizukami" />
+      <GimmeLoader extent="mizukami" />
       <HydrologyChartControls />
       <HydrologyChart label="Runoff" units="㎜" dataKey="runoff" />
 

--- a/components/global/HydrologySm.vue
+++ b/components/global/HydrologySm.vue
@@ -127,7 +127,7 @@ onUnmounted(() => {
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Soil Moisture</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         The map below shows the mean monthly soil moisture for soil layers
         1&ndash;3 across three 30-year eras using the CanESM2 model under the
@@ -173,7 +173,7 @@ onUnmounted(() => {
         where you can download the data that is used to populate the charts.
       </p>
 
-      <Gimme extent="mizukami" />
+      <GimmeLoader extent="mizukami" />
       <HydrologyChartControls />
       <HydrologyChart
         label="Soil moisture, layer 1"

--- a/components/global/HydrologySnowMelt.vue
+++ b/components/global/HydrologySnowMelt.vue
@@ -59,7 +59,7 @@ onUnmounted(() => {
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Snow Melt</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         The map below shows the 30-year mean annual snow melt for three eras
         using the CanESM2 model under the RCP 8.5 emissions scenario.
@@ -86,7 +86,7 @@ onUnmounted(() => {
         where you can download the data that is used to populate the chart.
       </p>
 
-      <Gimme extent="mizukami" />
+      <GimmeLoader extent="mizukami" />
       <HydrologyChartControls defaultMonth="mar" />
       <HydrologyChart label="Snow melt" units="㎜" dataKey="snow_melt" />
 

--- a/components/global/IndicatorDwCmip6.vue
+++ b/components/global/IndicatorDwCmip6.vue
@@ -91,7 +91,7 @@ mapStore.setLegendItems(mapId, legend)
         where you can download the data that is used to populate the chart.
       </p>
 
-      <Gimme :bbox="[-180, 50, 180, 90]" />
+      <GimmeLoader :bbox="[-180, 50, 180, 90]" />
       <IndicatorsCmip6ChartControls />
       <IndicatorsCmip6Chart label="Deep winter days" dataKey="dw" />
 

--- a/components/global/IndicatorFtcCmip6.vue
+++ b/components/global/IndicatorFtcCmip6.vue
@@ -92,7 +92,7 @@ mapStore.setLegendItems(mapId, legend)
         where you can download the data that is used to populate the chart.
       </p>
 
-      <Gimme :bbox="[-180, 50, 180, 90]" />
+      <GimmeLoader :bbox="[-180, 50, 180, 90]" />
       <IndicatorsCmip6ChartControls />
       <IndicatorsCmip6Chart
         label="Freeze/thaw cycle"

--- a/components/global/IndicatorRx1dayCmip6.vue
+++ b/components/global/IndicatorRx1dayCmip6.vue
@@ -91,7 +91,7 @@ mapStore.setLegendItems(mapId, legend)
         populate the chart.
       </p>
 
-      <Gimme :bbox="[-180, 50, 180, 90]" />
+      <GimmeLoader :bbox="[-180, 50, 180, 90]" />
       <IndicatorsCmip6ChartControls />
       <IndicatorsCmip6Chart
         label="Maximum 1-day precipitation"

--- a/components/global/IndicatorSuCmip6.vue
+++ b/components/global/IndicatorSuCmip6.vue
@@ -90,7 +90,7 @@ mapStore.setLegendItems(mapId, legend)
         where you can download the data that is used to populate the chart.
       </p>
 
-      <Gimme :bbox="[-180, 50, 180, 90]" />
+      <GimmeLoader :bbox="[-180, 50, 180, 90]" />
       <IndicatorsCmip6ChartControls />
       <IndicatorsCmip6Chart label="Summer days" dataKey="su" />
 

--- a/components/global/LandfastSeaIce.vue
+++ b/components/global/LandfastSeaIce.vue
@@ -362,7 +362,7 @@ onUnmounted(() => {
         is used to populate the chart.
       </p>
 
-      <Gimme extent="slie" ocean />
+      <GimmeLoader extent="slie" ocean />
 
       <div v-if="latLng && apiData">
         <div class="parameter">

--- a/components/global/OceanographyCmip6.vue
+++ b/components/global/OceanographyCmip6.vue
@@ -136,7 +136,7 @@ onUnmounted(() => {
         charts.
       </p>
 
-      <Gimme :bbox="[-180, 50, 180, 90]" />
+      <GimmeLoader :bbox="[-180, 50, 180, 90]" />
       <Cmip6MonthlyChartControls
         defaultMonth="08"
         :datasetKeys="['psl', 'ts']"

--- a/components/global/PermafrostBaseTop.vue
+++ b/components/global/PermafrostBaseTop.vue
@@ -99,7 +99,7 @@ onUnmounted(() => {
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Permafrost Depth: Base & Top</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         The map below shows permafrost base and top depth for three eras using
         the GFDL CM3 under the RCP 8.5 emissions scenario.
@@ -139,7 +139,7 @@ onUnmounted(() => {
         can download the data that is used to populate the charts.
       </p>
 
-      <Gimme extent="alaska" />
+      <GimmeLoader extent="alaska" />
       <PermafrostChartControls />
       <PermafrostChart
         label="Depth of permafrost base"

--- a/components/global/PermafrostMagt.vue
+++ b/components/global/PermafrostMagt.vue
@@ -65,7 +65,7 @@ onUnmounted(() => {
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Ground Temperature</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         The map below shows mean annual ground temperature at 3 meters depth for
         three eras using the GFDL CM3 under the RCP 8.5 emissions scenario.
@@ -95,7 +95,7 @@ onUnmounted(() => {
         can download the data that is used to populate the charts.
       </p>
 
-      <Gimme extent="alaska" />
+      <GimmeLoader extent="alaska" />
       <PermafrostChartControls />
       <PermafrostChart
         label="Mean annual ground temperature"

--- a/components/global/PermafrostTalik.vue
+++ b/components/global/PermafrostTalik.vue
@@ -59,7 +59,7 @@ onUnmounted(() => {
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Talik Thickness</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         The map below shows talik thickness for three eras using the GFDL CM3
         model under the RCP 8.5 emissions scenario.
@@ -86,7 +86,7 @@ onUnmounted(() => {
         data that is used to populate the chart.
       </p>
 
-      <Gimme extent="alaska" />
+      <GimmeLoader extent="alaska" />
       <PermafrostChartControls />
       <PermafrostChart
         label="Talik thickness"

--- a/components/global/PrecipitationCmip6.vue
+++ b/components/global/PrecipitationCmip6.vue
@@ -160,7 +160,7 @@ onUnmounted(() => {
         download the data that is used to populate the chart.
       </p>
 
-      <Gimme :bbox="[-180, 50, 180, 90]" />
+      <GimmeLoader :bbox="[-180, 50, 180, 90]" />
       <Cmip6MonthlyChartControls defaultMonth="08" :datasetKeys="['pr']" />
       <Cmip6MonthlyChart label="Precipitation" units="㎜" dataKey="pr" />
 

--- a/components/global/PrecipitationFrequency.vue
+++ b/components/global/PrecipitationFrequency.vue
@@ -240,7 +240,7 @@ onUnmounted(() => {
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Precipitation Frequency</h3>
-      <XrayIntroblurb resolution="20" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="20" unit="km" cmip="5" />
       <p>
         The following results are precipitation frequencies by duration and
         exceedance probability derived from two CMIP5 climate simulations
@@ -297,7 +297,7 @@ onUnmounted(() => {
         download the data that is used to populate the chart.
       </p>
 
-      <Gimme extent="alaska" />
+      <GimmeLoader extent="alaska" />
 
       <div v-if="latLng && apiData">
         <div class="chart-input">

--- a/components/global/SeaIceCmip6.vue
+++ b/components/global/SeaIceCmip6.vue
@@ -160,7 +160,11 @@ mapStore.setLegendItems(mapId, legend)
         of this dataset.
       </p>
 
-      <Gimme :bbox="[-180, 45, 180, 90]" ocean :communitiesEnabled="false" />
+      <GimmeLoader
+        :bbox="[-180, 45, 180, 90]"
+        ocean
+        :communitiesEnabled="false"
+      />
       <Cmip6MonthlyChartControls
         defaultModel="MIROC6"
         defaultMonth="03"

--- a/components/global/SeaIceConcentration.vue
+++ b/components/global/SeaIceConcentration.vue
@@ -238,10 +238,7 @@ onUnmounted(() => {
         populate the chart.
       </p>
 
-      <Gimme
-        :bbox="[-180, 45, 180, 90]"
-        ocean
-      />
+      <GimmeLoader :bbox="[-180, 45, 180, 90]" ocean />
 
       <div v-if="latLng && apiData">
         <div class="parameter">

--- a/components/global/SnowCmip6.vue
+++ b/components/global/SnowCmip6.vue
@@ -291,7 +291,7 @@ mapStore.setLegendItems(mapId, legend)
         used to populate the chart.
       </p>
 
-      <Gimme :bbox="[-180, 45, 180, 90]" />
+      <GimmeLoader :bbox="[-180, 45, 180, 90]" />
       <Cmip6MonthlyChartControls
         defaultModel="MIROC6"
         defaultMonth="12"

--- a/components/global/SolarRadiationCloudCoverCmip6.vue
+++ b/components/global/SolarRadiationCloudCoverCmip6.vue
@@ -204,7 +204,7 @@ onUnmounted(() => {
         used to populate the charts.
       </p>
 
-      <Gimme :bbox="[-180, 50, 180, 90]" />
+      <GimmeLoader :bbox="[-180, 50, 180, 90]" />
       <Cmip6MonthlyChartControls
         defaultModel="HadGEM3-GC31-MM"
         defaultMonth="08"

--- a/components/global/StoryClimateStripes1.vue
+++ b/components/global/StoryClimateStripes1.vue
@@ -281,7 +281,7 @@ onUnmounted(() => {
         data.
       </p>
       <p></p>
-      <Gimme
+      <GimmeLoader
         label="Get climate stripes for a community or by lat/long:"
         class="mt-5"
       />

--- a/components/global/TemperatureCmip6.vue
+++ b/components/global/TemperatureCmip6.vue
@@ -171,7 +171,7 @@ onUnmounted(() => {
         download the data that is used to populate the charts.
       </p>
 
-      <Gimme :bbox="[-180, 50, 180, 90]" />
+      <GimmeLoader :bbox="[-180, 50, 180, 90]" />
       <Cmip6MonthlyChartControls
         defaultModel="GFDL-ESM4"
         defaultMonth="07"

--- a/components/global/WetDaysPerYear.vue
+++ b/components/global/WetDaysPerYear.vue
@@ -272,7 +272,7 @@ onUnmounted(() => {
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Wet Days Per Year</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         A wet day is defined as a day with precipitation accumulation greater
         than or equal to 1.0㎜. The map below shows the 30-year mean of wet days
@@ -310,7 +310,7 @@ onUnmounted(() => {
         download the data that is used to populate the chart.
       </p>
 
-      <Gimme extent="blockyAlaska" />
+      <GimmeLoader extent="blockyAlaska" />
       <div id="chart"></div>
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">

--- a/components/global/WindCmip6.vue
+++ b/components/global/WindCmip6.vue
@@ -185,7 +185,7 @@ onUnmounted(() => {
         can download the data that is used to populate the charts.
       </p>
 
-      <Gimme :bbox="[-180, 50, 180, 90]" />
+      <GimmeLoader :bbox="[-180, 50, 180, 90]" />
       <Cmip6MonthlyChartControls
         defaultMonth="08"
         :datasetKeys="['sfcWind', 'uas', 'vas']"

--- a/stores/places.ts
+++ b/stores/places.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 const runtimeConfig = useRuntimeConfig()
 
 export const usePlacesStore = defineStore('places', () => {
+  const gimmeLoaded = ref(false)
   const selectedCommunity: Ref<CommunityValue> = ref(undefined)
   const latLng: Ref<LatLngValue> = ref(undefined)
 
@@ -13,6 +14,7 @@ export const usePlacesStore = defineStore('places', () => {
   }
   return {
     fetchCommunities,
+    gimmeLoaded,
     latLng,
     selectedCommunity,
   }


### PR DESCRIPTION
Closes #219.

**Note: I'm not sure if this PR is too substantial for post-launch cleanup. If so, I'll mark this PR as a draft and save it for the next development push.**

This PR solves the long pauses experienced when loading any ARDAC item that uses the `<Gimme />` place selector component. This was already a problem before our most recent launch, but seems to have gotten worse since including ~2,000 more international communities because Turf.js is performing point/polygon intersection operations to determine which communities fall within the data extent polygon.

The long pause sometimes shows as a blank white page, or sometimes the front page of the webapp, and seems to last anywhere from 1-4 seconds. Try loading this URL several times in different browsers to see:

https://arcticdatascience.org/item/permafrost-talik

This PR implements a new `<GimmeLoader />` component that changes the way the Gimme component is loaded. The app loads everything else on the page first, detects when everything has loaded, and only then loads the Gimme component & does the Turf.js intersection operations. A spinner is displayed where the Gimme component will appear until the Gimme component is ready.

To test, create & preview a static build of the webapp to more accurately simulate production:

```
nvm use lts/hydrogen
npm run build
npm run preview
```

Then try visiting this URL and observe how fast the page loads vs. the production URL above:

http://localhost:3000/item/permafrost-talik

Also verify that the place selector still works as expected once it loads.