### PR TITLE
Add support for multiple dataset chart families on the same page

### DIFF
--- a/components/Cmip6MonthlyChart.vue
+++ b/components/Cmip6MonthlyChart.vue
@@ -7,6 +7,8 @@ const props = defineProps<{
   multiplier?: number
 }>()
 
+const endpoint = 'cmip6Monthly'
+
 import type { Data } from 'plotly.js-dist-min'
 import { isProxy, toRaw } from 'vue'
 
@@ -22,14 +24,14 @@ const dataStore = useDataStore()
 const placesStore = usePlacesStore()
 const chartStore = useChartStore()
 
-const apiData = computed<any[]>(() => dataStore.apiData)
+const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const chartLabels = computed<Cmip6MonthlyChartLabelsObj>(
-  () => chartStore.labels as Cmip6MonthlyChartLabelsObj
+  () => chartStore.labels[endpoint] as Cmip6MonthlyChartLabelsObj
 )
 const chartInputs = computed<Cmip6MonthlyChartInputsObj>(
-  () => chartStore.inputs as Cmip6MonthlyChartInputsObj
+  () => chartStore.inputs[endpoint] as Cmip6MonthlyChartInputsObj
 )
 
 const chartId = computed<string>(() => props.dataKey + '-chart')
@@ -57,7 +59,7 @@ const monthMinMax = (values: any, month: string, dataKey: string) => {
 const buildChart = () => {
   if (apiData.value && chartLabels.value && chartInputs.value) {
     let traces: Data[] = []
-    let chartData = dataStore.apiData
+    let chartData = dataStore.apiData[endpoint]
     let projectedStartYear = 2015
 
     // Unwrap for performance reasons
@@ -234,7 +236,7 @@ watch(latLng, async () => {
 })
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 

--- a/components/Cmip6MonthlyChartControls.vue
+++ b/components/Cmip6MonthlyChartControls.vue
@@ -5,6 +5,8 @@ const props = defineProps<{
   datasetKeys?: string[]
 }>()
 
+const endpoint = 'cmip6Monthly'
+
 const dataStore = useDataStore()
 const placesStore = usePlacesStore()
 const chartStore = useChartStore()
@@ -23,14 +25,14 @@ if (props.defaultMonth) {
   monthInput.value = props.defaultMonth
 }
 
-const apiData = computed<any[]>(() => dataStore.apiData)
+const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const chartLabels = computed<Cmip6MonthlyChartLabels>(
-  () => chartStore.labels as Cmip6MonthlyChartLabels
+  () => chartStore.labels[endpoint] as Cmip6MonthlyChartLabels
 )
 
-chartStore.labels = {
+chartStore.labels[endpoint] = {
   models: {
     CESM2: 'CESM2',
     'CNRM-CM6-1-HR': 'CNRM-CM6-1-HR',
@@ -70,8 +72,8 @@ chartStore.labels = {
 // Sea ice concentration data is only available for some models.
 if (props.datasetKeys?.includes('siconc')) {
   if (props.datasetKeys?.includes('siconc')) {
-    chartStore.labels = {
-      ...chartStore.labels,
+    chartStore.labels[endpoint] = {
+      ...chartStore.labels[endpoint],
       models: {
         'HadGEM3-GC31-LL': 'HadGEM3-GC31-LL',
         'HadGEM3-GC31-MM': 'HadGEM3-GC31-MM',
@@ -96,7 +98,7 @@ watch([latLng, modelInput, scenarioInput, monthInput], async () => {
   if (!scenarioPresent(scenarioInput.value)) {
     scenarioInput.value = defaultScenario
   }
-  chartStore.inputs = {
+  chartStore.inputs[endpoint] = {
     model: modelInput.value,
     scenario: scenarioInput.value,
     month: monthInput.value,
@@ -104,7 +106,7 @@ watch([latLng, modelInput, scenarioInput, monthInput], async () => {
 })
 
 watch(latLng, async () => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
   let params = ''
   if (props.datasetKeys) {
     params = '?vars=' + props.datasetKeys.join(',')

--- a/components/DegreeDaysChart.vue
+++ b/components/DegreeDaysChart.vue
@@ -4,6 +4,8 @@ const props = defineProps<{
   label: string
 }>()
 
+const endpoint = props.endpoint
+
 import type { Data } from 'plotly.js-dist-min'
 import { precisionMean } from '~/utils/math'
 
@@ -11,7 +13,7 @@ const { $Plotly, $_ } = useNuxtApp()
 const dataStore = useDataStore()
 const placesStore = usePlacesStore()
 
-const apiData = computed<any[]>(() => dataStore.apiData)
+const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 let chartData: any
@@ -217,12 +219,12 @@ watch(apiData, async () => {
 
 watch(latLng, async () => {
   $Plotly.purge('chart')
-  dataStore.apiData = null
-  dataStore.fetchData(props.endpoint)
+  dataStore.apiData[endpoint] = null
+  dataStore.fetchData(endpoint)
 })
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 

--- a/components/DegreeDaysChart.vue
+++ b/components/DegreeDaysChart.vue
@@ -89,7 +89,7 @@ const buildChart = () => {
   if (apiData.value) {
     let traces: Data[] = []
     let allDecades: string[] = ['']
-    chartData = dataStore.apiData
+    chartData = dataStore.apiData[props.endpoint]
 
     for (let i = 1980; i <= 2090; i += 10) {
       allDecades.push(i + '-' + (i + 9))

--- a/components/Gimme.vue
+++ b/components/Gimme.vue
@@ -278,6 +278,7 @@ async function clearSelectedPlace() {
   placeIsSelected.value = false
   placeSelectionType.value = undefined
   inputValue.value = '' // clear input
+  fieldMessage.value = '' // clear field message
   latLngIsValid.value = false // hide button
 
   await nextTick() // so the focus works
@@ -297,7 +298,7 @@ const nothingButErrors = computed(() => {
 })
 
 const dataStore = useDataStore()
-const dataErrors = computed<Record<string, boolean>>(() => dataStore.dataError)
+const dataErrors = computed<Record<string, boolean>>(() => dataStore.dataErrors)
 watch(nothingButErrors, async () => {
   if (nothingButErrors) {
     fieldMessage.value =

--- a/components/Gimme.vue
+++ b/components/Gimme.vue
@@ -292,12 +292,18 @@ const placeName = computed(() => {
   }
 })
 
+const nothingButErrors = computed(() => {
+  return Object.values(dataErrors.value).every(error => error == true)
+})
+
 const dataStore = useDataStore()
-const dataError = computed<boolean>(() => dataStore.dataError)
-watch(dataError, async () => {
-  if (dataError.value == true) {
+const dataErrors = computed<Record<string, boolean>>(() => dataStore.dataError)
+watch(nothingButErrors, async () => {
+  if (nothingButErrors) {
     fieldMessage.value =
       '⚠️ Failed to load data for the selected location. Please choose a different location.'
+  } else {
+    fieldMessage.value = ''
   }
 })
 
@@ -309,7 +315,7 @@ onUnmounted(() => {
 
 <template>
   <div class="my-3">
-    <div v-show="placeIsSelected && !dataError" class="selected-place">
+    <div v-show="placeIsSelected && !nothingButErrors" class="selected-place">
       <div class="content is-size-5">
         <p>
           Showing data for
@@ -323,7 +329,7 @@ onUnmounted(() => {
         </p>
       </div>
     </div>
-    <div v-show="!placeIsSelected || dataError" class="field">
+    <div v-show="!placeIsSelected || nothingButErrors" class="field">
       <div class="control">
         <label class="label is-size-4"
           >Get data for

--- a/components/HydrologyChart.vue
+++ b/components/HydrologyChart.vue
@@ -5,6 +5,8 @@ const props = defineProps<{
   dataKey: string
 }>()
 
+const endpoint = 'hydrology'
+
 import type { Data } from 'plotly.js-dist-min'
 
 const { $Plotly, $_ } = useNuxtApp()
@@ -12,14 +14,14 @@ const dataStore = useDataStore()
 const placesStore = usePlacesStore()
 const chartStore = useChartStore()
 
-const apiData = computed<any[]>(() => dataStore.apiData)
+const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const chartLabels = computed<HydrologyChartLabelsObj>(
-  () => chartStore.labels as HydrologyChartLabelsObj
+  () => chartStore.labels[endpoint] as HydrologyChartLabelsObj
 )
 const chartInputs = computed<HydrologyChartInputsObj>(
-  () => chartStore.inputs as HydrologyChartInputsObj
+  () => chartStore.inputs[endpoint] as HydrologyChartInputsObj
 )
 
 const chartId = computed<string>(() => props.dataKey + '-chart')
@@ -138,7 +140,7 @@ watch(latLng, async () => {
 })
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 

--- a/components/HydrologyChart.vue
+++ b/components/HydrologyChart.vue
@@ -47,7 +47,7 @@ const buildChart = () => {
     ]
 
     let traces: Data[] = []
-    let chartData = dataStore.apiData.hydrology
+    let chartData = dataStore.apiData[endpoint]
     let means: number[] = []
 
     decades.forEach(decade => {

--- a/components/HydrologyChart.vue
+++ b/components/HydrologyChart.vue
@@ -47,7 +47,7 @@ const buildChart = () => {
     ]
 
     let traces: Data[] = []
-    let chartData = dataStore.apiData
+    let chartData = dataStore.apiData.hydrology
     let means: number[] = []
 
     decades.forEach(decade => {

--- a/components/HydrologyChartControls.vue
+++ b/components/HydrologyChartControls.vue
@@ -3,6 +3,8 @@ const props = defineProps<{
   defaultMonth?: string
 }>()
 
+const endpoint = 'hydrology'
+
 const dataStore = useDataStore()
 const placesStore = usePlacesStore()
 const chartStore = useChartStore()
@@ -15,14 +17,14 @@ if (props.defaultMonth) {
   monthInput.value = props.defaultMonth
 }
 
-const apiData = computed<any[]>(() => dataStore.apiData)
+const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const chartLabels = computed<HydrologyChartLabels>(
-  () => chartStore.labels as HydrologyChartLabels
+  () => chartStore.labels[endpoint] as HydrologyChartLabels
 )
 
-chartStore.labels = {
+chartStore.labels[endpoint] = {
   models: {
     'ACCESS1-3': 'ACCESS1-3',
     CCSM4: 'CCSM4',
@@ -56,7 +58,7 @@ chartStore.labels = {
 }
 
 watch([latLng, modelInput, scenarioInput, monthInput], async () => {
-  chartStore.inputs = {
+  chartStore.inputs[endpoint] = {
     model: modelInput.value,
     scenario: scenarioInput.value,
     month: monthInput.value,
@@ -64,8 +66,8 @@ watch([latLng, modelInput, scenarioInput, monthInput], async () => {
 })
 
 watch(latLng, async () => {
-  dataStore.apiData = null
-  dataStore.fetchData('hydrology')
+  dataStore.apiData[endpoint] = null
+  dataStore.fetchData(endpoint)
 })
 </script>
 

--- a/components/IndicatorsChart.vue
+++ b/components/IndicatorsChart.vue
@@ -41,7 +41,7 @@ const buildChart = () => {
       'NCAR-CCSM4': 'diamond',
     }
     let ticks: number[] = [1, 2, 3]
-    let chartData = dataStore.apiData.indicators[props.dataKey]
+    let chartData = dataStore.apiData[endpoint][props.dataKey]
 
     let means: Array<number | null> = []
     let maxes: Array<number | null> = []

--- a/components/IndicatorsChart.vue
+++ b/components/IndicatorsChart.vue
@@ -5,6 +5,8 @@ const props = defineProps<{
   dataKey: string
 }>()
 
+const endpoint = 'indicators'
+
 import type { Data } from 'plotly.js-dist-min'
 
 const { $Plotly, $_ } = useNuxtApp()
@@ -13,7 +15,7 @@ const placesStore = usePlacesStore()
 
 const scenarioInput = defineModel({ default: 'rcp85' })
 
-const apiData = computed<any[]>(() => dataStore.apiData)
+const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const scenarioLabels: Record<string, string> = {
@@ -201,12 +203,12 @@ watch([apiData, scenarioInput], async () => {
 
 watch(latLng, async () => {
   $Plotly.purge('chart')
-  dataStore.apiData = null
-  dataStore.fetchData('indicators')
+  dataStore.apiData[endpoint] = null
+  dataStore.fetchData(endpoint)
 })
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 

--- a/components/IndicatorsChart.vue
+++ b/components/IndicatorsChart.vue
@@ -41,7 +41,7 @@ const buildChart = () => {
       'NCAR-CCSM4': 'diamond',
     }
     let ticks: number[] = [1, 2, 3]
-    let chartData = dataStore.apiData[props.dataKey]
+    let chartData = dataStore.apiData.indicators[props.dataKey]
 
     let means: Array<number | null> = []
     let maxes: Array<number | null> = []

--- a/components/IndicatorsCmip6Chart.vue
+++ b/components/IndicatorsCmip6Chart.vue
@@ -5,6 +5,8 @@ const props = defineProps<{
   dataKey: string
 }>()
 
+const endpoint = 'indicatorsCmip6'
+
 import type { Data } from 'plotly.js-dist-min'
 import { precisionMean } from '~/utils/math'
 
@@ -13,14 +15,14 @@ const dataStore = useDataStore()
 const placesStore = usePlacesStore()
 const chartStore = useChartStore()
 
-const apiData = computed<any[]>(() => dataStore.apiData)
+const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const chartLabels = computed<IndicatorsCmip6ChartLabelsObj>(
-  () => chartStore.labels as IndicatorsCmip6ChartLabelsObj
+  () => chartStore.labels[endpoint] as IndicatorsCmip6ChartLabelsObj
 )
 const chartInputs = computed<IndicatorsCmip6ChartInputsObj>(
-  () => chartStore.inputs as IndicatorsCmip6ChartInputsObj
+  () => chartStore.inputs[endpoint] as IndicatorsCmip6ChartInputsObj
 )
 
 let chartData: any
@@ -131,7 +133,7 @@ const buildChart = () => {
   if (apiData.value && chartLabels.value && chartInputs.value) {
     let traces: Data[] = []
     let allDecades: string[] = []
-    chartData = dataStore.apiData
+    chartData = dataStore.apiData[endpoint]
 
     // Unwrap for performance reasons
     if (isProxy(chartData)) {
@@ -266,7 +268,7 @@ watch(latLng, async () => {
 })
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 

--- a/components/IndicatorsCmip6ChartControls.vue
+++ b/components/IndicatorsCmip6ChartControls.vue
@@ -3,6 +3,8 @@ const props = defineProps<{
   defaultMonth?: string
 }>()
 
+const endpoint = 'indicatorsCmip6'
+
 const dataStore = useDataStore()
 const placesStore = usePlacesStore()
 const chartStore = useChartStore()
@@ -12,14 +14,14 @@ const defaultScenario = 'ssp585'
 const modelInput = defineModel('model', { default: 'TaiESM1' })
 const scenarioInput = defineModel('scenario', { default: defaultScenario })
 
-const apiData = computed<any[]>(() => dataStore.apiData)
+const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const chartLabels = computed<IndicatorsCmip6ChartLabels>(
-  () => chartStore.labels as IndicatorsCmip6ChartLabels
+  () => chartStore.labels[endpoint] as IndicatorsCmip6ChartLabels
 )
 
-chartStore.labels = {
+chartStore.labels[endpoint] = {
   models: {
     CESM2: 'CESM2',
     'CNRM-CM6-1-HR': 'CNRM-CM6-1-HR',
@@ -52,7 +54,7 @@ const scenarioPresent = (value: string) => {
 }
 
 watch(latLng, async () => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
   dataStore.fetchData('indicatorsCmip6')
 })
 
@@ -60,7 +62,7 @@ watch([latLng, modelInput, scenarioInput], async () => {
   if (!scenarioPresent(scenarioInput.value)) {
     scenarioInput.value = defaultScenario
   }
-  chartStore.inputs = {
+  chartStore.inputs[endpoint] = {
     model: modelInput.value,
     scenario: scenarioInput.value,
   }

--- a/components/LoadIndicator.vue
+++ b/components/LoadIndicator.vue
@@ -3,7 +3,7 @@ const placesStore = usePlacesStore()
 const dataStore = useDataStore()
 
 const apiData = computed<any>(() => dataStore.apiData)
-const dataErrors = computed<any>(() => dataStore.dataError)
+const dataErrors = computed<any>(() => dataStore.dataErrors)
 
 const anyApiData = computed(() => {
   return Object.values(apiData.value).some(

--- a/components/LoadIndicator.vue
+++ b/components/LoadIndicator.vue
@@ -1,10 +1,26 @@
 <script lang="ts" setup>
 const placesStore = usePlacesStore()
 const dataStore = useDataStore()
+
+const apiData = computed<any>(() => dataStore.apiData)
+const dataErrors = computed<any>(() => dataStore.dataError)
+
+const anyApiData = computed(() => {
+  return Object.values(apiData.value).some(
+    value =>
+      typeof value === 'object' &&
+      value != null &&
+      Object.keys(value).length > 0
+  )
+})
+
+const anyDataErrors = computed(() => {
+  return Object.values(dataErrors.value).some(value => value == true)
+})
 </script>
 
 <template>
-  <div v-if="placesStore.latLng && !dataStore.apiData && !dataStore.dataError">
+  <div v-if="placesStore.latLng && !anyApiData && !anyDataErrors">
     <progress class="progress" />
   </div>
 </template>

--- a/components/PermafrostChart.vue
+++ b/components/PermafrostChart.vue
@@ -87,7 +87,7 @@ const buildChart = () => {
   if (apiData.value) {
     let traces: Data[] = []
     let allDecades: string[] = ['']
-    chartData = dataStore.apiData.permafrost
+    chartData = dataStore.apiData[endpoint]
 
     for (let i = 2021; i <= 2120; i += 10) {
       allDecades.push(i + '-' + (i + 9))

--- a/components/PermafrostChart.vue
+++ b/components/PermafrostChart.vue
@@ -87,7 +87,7 @@ const buildChart = () => {
   if (apiData.value) {
     let traces: Data[] = []
     let allDecades: string[] = ['']
-    chartData = dataStore.apiData
+    chartData = dataStore.apiData.permafrost
 
     for (let i = 2021; i <= 2120; i += 10) {
       allDecades.push(i + '-' + (i + 9))

--- a/components/PermafrostChart.vue
+++ b/components/PermafrostChart.vue
@@ -6,6 +6,8 @@ const props = defineProps<{
   dataKey: string
 }>()
 
+const endpoint = 'permafrost'
+
 import type { Data } from 'plotly.js-dist-min'
 import { precisionMean } from '~/utils/math'
 
@@ -14,11 +16,11 @@ const dataStore = useDataStore()
 const placesStore = usePlacesStore()
 const chartStore = useChartStore()
 
-const apiData = computed<any[]>(() => dataStore.apiData)
+const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const chartInputs = computed<PermafrostChartInputs>(
-  () => chartStore.inputs as PermafrostChartInputs
+  () => chartStore.inputs[endpoint] as PermafrostChartInputs
 )
 
 const chartId = computed<string>(() => props.dataKey + '-chart')
@@ -224,7 +226,7 @@ watch(latLng, async () => {
 })
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 

--- a/components/PermafrostChartControls.vue
+++ b/components/PermafrostChartControls.vue
@@ -3,6 +3,8 @@ const props = defineProps<{
   defaultMonth?: string
 }>()
 
+const endpoint = 'permafrost'
+
 const dataStore = useDataStore()
 const placesStore = usePlacesStore()
 const chartStore = useChartStore()
@@ -10,23 +12,23 @@ const chartStore = useChartStore()
 const scenarioInput = defineModel({ default: 'RCP 8.5' })
 
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
-const apiData = computed<any[]>(() => dataStore.apiData)
+const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 
 const chartLabels = computed<PermafrostChartLabels>(
-  () => chartStore.labels as PermafrostChartLabels
+  () => chartStore.labels[endpoint] as PermafrostChartLabels
 )
 
-chartStore.labels = {
+chartStore.labels[endpoint] = {
   scenarios: { 'RCP 4.5': 'RCP 4.5', 'RCP 8.5': 'RCP 8.5' },
 }
 
 watch(latLng, async () => {
-  dataStore.apiData = null
-  dataStore.fetchData('permafrost')
+  dataStore.apiData[endpoint] = null
+  dataStore.fetchData(endpoint)
 })
 
 watch([latLng, scenarioInput], async () => {
-  chartStore.inputs = {
+  chartStore.inputs[endpoint] = {
     scenario: scenarioInput.value,
   }
 })

--- a/components/TasPrChart.vue
+++ b/components/TasPrChart.vue
@@ -29,7 +29,7 @@ const seasonInput = defineModel('season', { default: 'DJF' })
 const scenarioInput = defineModel('scenario', { default: 'rcp85' })
 
 const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
-const dataError = computed<boolean>(() => dataStore.dataError[endpoint])
+const dataError = computed<boolean>(() => dataStore.dataErrors[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 const errorMsg = ref('')
 

--- a/components/TasPrChart.vue
+++ b/components/TasPrChart.vue
@@ -6,6 +6,8 @@ const props = defineProps<{
   dataKey: string
 }>()
 
+const endpoint = props.endpoint
+
 import type { Data, BoxPlotData } from 'plotly.js-dist-min'
 
 // Add additional boxplot properties that are not included in
@@ -26,8 +28,8 @@ const placesStore = usePlacesStore()
 const seasonInput = defineModel('season', { default: 'DJF' })
 const scenarioInput = defineModel('scenario', { default: 'rcp85' })
 
-const apiData = computed<any[]>(() => dataStore.apiData)
-const dataError = computed<boolean>(() => dataStore.dataError)
+const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
+const dataError = computed<boolean>(() => dataStore.dataError[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 const errorMsg = ref('')
 
@@ -171,7 +173,7 @@ watch([apiData, seasonInput, scenarioInput], async () => {
 watch(latLng, async () => {
   errorMsg.value = ''
   $Plotly.purge('chart')
-  dataStore.fetchData(props.endpoint)
+  dataStore.fetchData(endpoint)
 })
 
 watch(dataError, async () => {
@@ -182,7 +184,7 @@ watch(dataError, async () => {
 })
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 

--- a/components/global/AlfrescoFlammability.vue
+++ b/components/global/AlfrescoFlammability.vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+const endpoint = 'flammability'
+
 import type { Data } from 'plotly.js-dist-min'
 
 const { $Plotly, $_ } = useNuxtApp()
@@ -10,7 +12,7 @@ const runtimeConfig = useRuntimeConfig()
 const modelInput = defineModel('model', { default: 'NCAR-CCSM4' })
 const scenarioInput = defineModel('scenario', { default: 'rcp85' })
 
-const apiData = computed<any>(() => dataStore.apiData)
+const apiData = computed<any>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const models = [
@@ -185,11 +187,11 @@ watch([apiData, modelInput, scenarioInput], async () => {
 
 watch(latLng, async () => {
   $Plotly.purge('chart')
-  dataStore.fetchData('flammability')
+  dataStore.fetchData(endpoint)
 })
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 
@@ -208,7 +210,13 @@ onUnmounted(() => {
 
       <MapBlock :mapId="mapId" class="mb-6">
         <template v-slot:layers>
-          <MapLayer v-for="layer in layers" :mapId="mapId" :layer="layer" :key="layer.id" :default="layer.default">
+          <MapLayer
+            v-for="layer in layers"
+            :mapId="mapId"
+            :layer="layer"
+            :key="layer.id"
+            :default="layer.default"
+          >
             <template v-slot:title>{{ layer.title }}</template>
           </MapLayer>
         </template>

--- a/components/global/AlfrescoVegetation.vue
+++ b/components/global/AlfrescoVegetation.vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+const endpoint = 'vegType'
+
 import type { Data } from 'plotly.js-dist-min'
 
 const { $Plotly, $_ } = useNuxtApp()
@@ -10,7 +12,7 @@ const runtimeConfig = useRuntimeConfig()
 const modelInput = defineModel('model', { default: 'NCAR-CCSM4' })
 const scenarioInput = defineModel('scenario', { default: 'rcp85' })
 
-const apiData = computed<any>(() => dataStore.apiData)
+const apiData = computed<any>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const models = [
@@ -190,11 +192,11 @@ watch([apiData, modelInput, scenarioInput], async () => {
 
 watch(latLng, async () => {
   $Plotly.purge('chart')
-  dataStore.fetchData('vegType')
+  dataStore.fetchData(endpoint)
 })
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 

--- a/components/global/ClimateBeetleProtection.vue
+++ b/components/global/ClimateBeetleProtection.vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+const endpoint = 'beetles'
+
 const placesStore = usePlacesStore()
 const mapStore = useMapStore()
 const dataStore = useDataStore()
@@ -7,7 +9,7 @@ const runtimeConfig = useRuntimeConfig()
 const snowpackInput = defineModel('snowpack', { default: 'medium' })
 const scenarioInput = defineModel('scenario', { default: 'rcp85' })
 
-const apiData = computed<Record<string, any>>(() => dataStore.apiData)
+const apiData = computed<Record<string, any>>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const eras = ['2010-2039', '2040-2069', '2070-2099']
@@ -80,12 +82,12 @@ const mapId = 'beetles'
 mapStore.setLegendItems(mapId, legend)
 
 watch(latLng, async () => {
-  dataStore.apiData = null
-  dataStore.fetchData('beetles')
+  dataStore.apiData[endpoint] = null
+  dataStore.fetchData(endpoint)
 })
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 

--- a/components/global/Elevation.vue
+++ b/components/global/Elevation.vue
@@ -1,10 +1,12 @@
 <script lang="ts" setup>
+const endpoint = 'elevation'
+
 const placesStore = usePlacesStore()
 const mapStore = useMapStore()
 const dataStore = useDataStore()
 const runtimeConfig = useRuntimeConfig()
 
-const apiData = computed<Record<string, any>>(() => dataStore.apiData)
+const apiData = computed<Record<string, any>>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const layers: MapLayer[] = [
@@ -45,12 +47,12 @@ const mapId = 'elevation'
 mapStore.setLegendItems(mapId, legend)
 
 watch(latLng, async () => {
-  dataStore.apiData = null
-  dataStore.fetchData('elevation')
+  dataStore.apiData[endpoint] = null
+  dataStore.fetchData(endpoint)
 })
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 
@@ -58,7 +60,7 @@ onUnmounted(() => {
   <section class="section">
     <div class="content is-size-5">
       <h3 class="title is-3">Elevation</h3>
-      <XrayIntroblurb resolution="1" unit="km"/>
+      <XrayIntroblurb resolution="1" unit="km" />
       <p class="mb-6">
         The map below shows minimum, mean, and maximum elevation at a resolution
         of 1km:

--- a/components/global/EvaporationCmip6.vue
+++ b/components/global/EvaporationCmip6.vue
@@ -1,10 +1,12 @@
 <script lang="ts" setup>
+const endpoint = 'cmip6Monthly'
+
 const placesStore = usePlacesStore()
 const mapStore = useMapStore()
 const dataStore = useDataStore()
 const runtimeConfig = useRuntimeConfig()
 
-const apiData = computed<any[]>(() => dataStore.apiData)
+const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const layers: MapLayer[] = [
@@ -147,7 +149,7 @@ const mapId = 'evspsbl'
 mapStore.setLegendItems(mapId, legend)
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 

--- a/components/global/HydrologyEvap.vue
+++ b/components/global/HydrologyEvap.vue
@@ -1,10 +1,12 @@
 <script lang="ts" setup>
+const endpoint = 'hydrology'
+
 const placesStore = usePlacesStore()
 const mapStore = useMapStore()
 const dataStore = useDataStore()
 const runtimeConfig = useRuntimeConfig()
 
-const apiData = computed<any[]>(() => dataStore.apiData)
+const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const layers: MapLayer[] = [
@@ -51,7 +53,7 @@ const mapId = 'evap'
 mapStore.setLegendItems(mapId, legend)
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 
@@ -59,7 +61,7 @@ onUnmounted(() => {
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Evapotranspiration</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         The map below shows the 30-year mean annual evapotranspiration for three
         eras using the CanESM2 model under the RCP 8.5 emissions scenario.

--- a/components/global/HydrologyGlacierMelt.vue
+++ b/components/global/HydrologyGlacierMelt.vue
@@ -1,10 +1,12 @@
 <script lang="ts" setup>
+const endpoint = 'hydrology'
+
 const placesStore = usePlacesStore()
 const mapStore = useMapStore()
 const dataStore = useDataStore()
 const runtimeConfig = useRuntimeConfig()
 
-const apiData = computed<any[]>(() => dataStore.apiData)
+const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const layers: MapLayer[] = [
@@ -51,7 +53,7 @@ const mapId = 'glacier_melt'
 mapStore.setLegendItems(mapId, legend)
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 
@@ -59,7 +61,7 @@ onUnmounted(() => {
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Glacier Melt</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         The map below shows the 30-year mean annual glacier melt for three eras
         using the CanESM2 model under the RCP 8.5 emissions scenario.

--- a/components/global/HydrologyIswe.vue
+++ b/components/global/HydrologyIswe.vue
@@ -1,10 +1,12 @@
 <script lang="ts" setup>
+const endpoint = 'hydrology'
+
 const placesStore = usePlacesStore()
 const mapStore = useMapStore()
 const dataStore = useDataStore()
 const runtimeConfig = useRuntimeConfig()
 
-const apiData = computed<any[]>(() => dataStore.apiData)
+const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const layers: MapLayer[] = [
@@ -85,7 +87,7 @@ const mapId = 'iswe'
 mapStore.setLegendItems(mapId, legend)
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 
@@ -93,7 +95,7 @@ onUnmounted(() => {
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Ice/Snow Water Equivalent</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         The map below shows the 30-year mean monthly ice/snow water equivalent
         for three eras using the CanESM2 model under the RCP 8.5 emissions

--- a/components/global/HydrologyRunoff.vue
+++ b/components/global/HydrologyRunoff.vue
@@ -1,10 +1,12 @@
 <script lang="ts" setup>
+const endpoint = 'hydrology'
+
 const placesStore = usePlacesStore()
 const mapStore = useMapStore()
 const dataStore = useDataStore()
 const runtimeConfig = useRuntimeConfig()
 
-const apiData = computed<any[]>(() => dataStore.apiData)
+const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const layers: MapLayer[] = [
@@ -51,7 +53,7 @@ const mapId = 'runoff'
 mapStore.setLegendItems(mapId, legend)
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 
@@ -59,7 +61,7 @@ onUnmounted(() => {
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Runoff</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         The map below shows the 30-year mean annual runoff for three eras using
         the CanESM2 model under the RCP 8.5 emissions scenario.

--- a/components/global/HydrologySm.vue
+++ b/components/global/HydrologySm.vue
@@ -1,10 +1,12 @@
 <script lang="ts" setup>
+const endpoint = 'hydrology'
+
 const placesStore = usePlacesStore()
 const mapStore = useMapStore()
 const dataStore = useDataStore()
 const runtimeConfig = useRuntimeConfig()
 
-const apiData = computed<any[]>(() => dataStore.apiData)
+const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const layers: MapLayer[] = [
@@ -119,7 +121,7 @@ const mapId = 'sm'
 mapStore.setLegendItems(mapId, legend)
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 
@@ -127,7 +129,7 @@ onUnmounted(() => {
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Soil Moisture</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         The map below shows the mean monthly soil moisture for soil layers
         1&ndash;3 across three 30-year eras using the CanESM2 model under the

--- a/components/global/HydrologySnowMelt.vue
+++ b/components/global/HydrologySnowMelt.vue
@@ -1,10 +1,12 @@
 <script lang="ts" setup>
+const endpoint = 'hydrology'
+
 const placesStore = usePlacesStore()
 const mapStore = useMapStore()
 const dataStore = useDataStore()
 const runtimeConfig = useRuntimeConfig()
 
-const apiData = computed<any[]>(() => dataStore.apiData)
+const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const layers: MapLayer[] = [
@@ -51,7 +53,7 @@ const mapId = 'snow_melt'
 mapStore.setLegendItems(mapId, legend)
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 
@@ -59,7 +61,7 @@ onUnmounted(() => {
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Snow Melt</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         The map below shows the 30-year mean annual snow melt for three eras
         using the CanESM2 model under the RCP 8.5 emissions scenario.

--- a/components/global/LandfastSeaIce.vue
+++ b/components/global/LandfastSeaIce.vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+const endpoint = 'landfastSeaIce'
+
 const placesStore = usePlacesStore()
 const mapStore = useMapStore()
 const dataStore = useDataStore()
@@ -9,7 +11,7 @@ import type { Data } from 'plotly.js-dist-min'
 
 const yearInput = defineModel('snowpack', { default: '2023' })
 
-const apiData = computed<Record<string, any>>(() => dataStore.apiData)
+const apiData = computed<Record<string, any>>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const years = $_.range(1996, 2024)
@@ -280,8 +282,8 @@ const buildChart = () => {
 
 watch(latLng, async () => {
   $Plotly.purge('chart')
-  dataStore.apiData = null
-  dataStore.fetchData('landfastSeaIce')
+  dataStore.apiData[endpoint] = null
+  dataStore.fetchData(endpoint)
 })
 
 watch([apiData, yearInput], async () => {
@@ -291,7 +293,7 @@ watch([apiData, yearInput], async () => {
 })
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 

--- a/components/global/OceanographyCmip6.vue
+++ b/components/global/OceanographyCmip6.vue
@@ -1,10 +1,12 @@
 <script lang="ts" setup>
+const endpoint = 'cmip6Monthly'
+
 const placesStore = usePlacesStore()
 const mapStore = useMapStore()
 const dataStore = useDataStore()
 const runtimeConfig = useRuntimeConfig()
 
-const apiData = computed<any[]>(() => dataStore.apiData)
+const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const layers: MapLayer[] = [
@@ -92,7 +94,7 @@ const mapId = 'psl_and_ts'
 mapStore.setLegendItems(mapId, legend)
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 

--- a/components/global/PermafrostBaseTop.vue
+++ b/components/global/PermafrostBaseTop.vue
@@ -1,10 +1,12 @@
 <script lang="ts" setup>
+const endpoint = 'permafrost'
+
 const mapStore = useMapStore()
 const dataStore = useDataStore()
 const placesStore = usePlacesStore()
 const runtimeConfig = useRuntimeConfig()
 
-const apiData = computed<any[]>(() => dataStore.apiData)
+const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const layers: MapLayer[] = [
@@ -91,7 +93,7 @@ const mapId = 'magt'
 mapStore.setLegendItems(mapId, legend)
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 
@@ -99,7 +101,7 @@ onUnmounted(() => {
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Permafrost Depth: Base & Top</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         The map below shows permafrost base and top depth for three eras using
         the GFDL CM3 under the RCP 8.5 emissions scenario.

--- a/components/global/PermafrostMagt.vue
+++ b/components/global/PermafrostMagt.vue
@@ -1,10 +1,12 @@
 <script lang="ts" setup>
+const endpoint = 'permafrost'
+
 const mapStore = useMapStore()
 const dataStore = useDataStore()
 const placesStore = usePlacesStore()
 const runtimeConfig = useRuntimeConfig()
 
-const apiData = computed<any[]>(() => dataStore.apiData)
+const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const layers: MapLayer[] = [
@@ -57,7 +59,7 @@ const mapId = 'magt'
 mapStore.setLegendItems(mapId, legend)
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 
@@ -65,7 +67,7 @@ onUnmounted(() => {
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Ground Temperature</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         The map below shows mean annual ground temperature at 3 meters depth for
         three eras using the GFDL CM3 under the RCP 8.5 emissions scenario.

--- a/components/global/PermafrostTalik.vue
+++ b/components/global/PermafrostTalik.vue
@@ -1,10 +1,12 @@
 <script lang="ts" setup>
+const endpoint = 'permafrost'
+
 const mapStore = useMapStore()
 const dataStore = useDataStore()
 const placesStore = usePlacesStore()
 const runtimeConfig = useRuntimeConfig()
 
-const apiData = computed<any[]>(() => dataStore.apiData)
+const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const layers: MapLayer[] = [
@@ -51,7 +53,7 @@ const mapId = 'talikthickness'
 mapStore.setLegendItems(mapId, legend)
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 
@@ -59,7 +61,7 @@ onUnmounted(() => {
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Talik Thickness</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         The map below shows talik thickness for three eras using the GFDL CM3
         model under the RCP 8.5 emissions scenario.

--- a/components/global/PrecipitationCmip6.vue
+++ b/components/global/PrecipitationCmip6.vue
@@ -1,10 +1,12 @@
 <script lang="ts" setup>
+const endpoint = 'cmip6Monthly'
+
 const placesStore = usePlacesStore()
 const mapStore = useMapStore()
 const dataStore = useDataStore()
 const runtimeConfig = useRuntimeConfig()
 
-const apiData = computed<any[]>(() => dataStore.apiData)
+const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const layers: MapLayer[] = [
@@ -123,7 +125,7 @@ const mapId = 'snow_melt'
 mapStore.setLegendItems(mapId, legend)
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 

--- a/components/global/PrecipitationFrequency.vue
+++ b/components/global/PrecipitationFrequency.vue
@@ -52,7 +52,7 @@ const buildChart = () => {
     }
     let ticks = [0, 1, 2, 3]
     let chartData =
-      dataStore.apiData.precipitationFrequency[returnIntervalInput.value][
+      dataStore.apiData[endpoint][returnIntervalInput.value][
         durationInput.value
       ]
     models.forEach(model => {

--- a/components/global/PrecipitationFrequency.vue
+++ b/components/global/PrecipitationFrequency.vue
@@ -52,7 +52,9 @@ const buildChart = () => {
     }
     let ticks = [0, 1, 2, 3]
     let chartData =
-      dataStore.apiData[returnIntervalInput.value][durationInput.value]
+      dataStore.apiData.precipitationFrequency[returnIntervalInput.value][
+        durationInput.value
+      ]
     models.forEach(model => {
       let pfs: number[] = []
       let pfUppers: number[] = []

--- a/components/global/PrecipitationFrequency.vue
+++ b/components/global/PrecipitationFrequency.vue
@@ -13,7 +13,7 @@ const durationInput = defineModel('duration', { default: '24h' })
 const returnIntervalInput = defineModel('returnInterval', { default: '100' })
 
 const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
-const dataError = computed<boolean>(() => dataStore.dataError[endpoint])
+const dataError = computed<boolean>(() => dataStore.dataErrors[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 const errorMsg = ref('')
 

--- a/components/global/PrecipitationFrequency.vue
+++ b/components/global/PrecipitationFrequency.vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+const endpoint = 'precipitationFrequency'
+
 import type { Data } from 'plotly.js-dist-min'
 
 const { $Plotly, $_ } = useNuxtApp()
@@ -10,8 +12,8 @@ const runtimeConfig = useRuntimeConfig()
 const durationInput = defineModel('duration', { default: '24h' })
 const returnIntervalInput = defineModel('returnInterval', { default: '100' })
 
-const apiData = computed<any[]>(() => dataStore.apiData)
-const dataError = computed<boolean>(() => dataStore.dataError)
+const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
+const dataError = computed<boolean>(() => dataStore.dataError[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 const errorMsg = ref('')
 
@@ -221,7 +223,7 @@ watch([apiData, durationInput, returnIntervalInput], async () => {
 watch(latLng, async () => {
   errorMsg.value = ''
   $Plotly.purge('chart')
-  dataStore.fetchData('precipitationFrequency')
+  dataStore.fetchData(endpoint)
 })
 
 watch(dataError, async () => {
@@ -232,7 +234,7 @@ watch(dataError, async () => {
 })
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 
@@ -240,7 +242,7 @@ onUnmounted(() => {
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Precipitation Frequency</h3>
-      <XrayIntroblurb resolution="20" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="20" unit="km" cmip="5" />
       <p>
         The following results are precipitation frequencies by duration and
         exceedance probability derived from two CMIP5 climate simulations

--- a/components/global/SeaIceConcentration.vue
+++ b/components/global/SeaIceConcentration.vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+const endpoint = 'seaIceConcentration'
+
 const placesStore = usePlacesStore()
 const mapStore = useMapStore()
 const dataStore = useDataStore()
@@ -9,7 +11,7 @@ import type { Data } from 'plotly.js-dist-min'
 
 const monthInput = defineModel({ default: '3' })
 
-const apiData = computed<Record<string, any>>(() => dataStore.apiData)
+const apiData = computed<Record<string, any>>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const years = $_.range(1850, 2021)
@@ -180,8 +182,8 @@ const buildChart = () => {
 
 watch(latLng, async () => {
   $Plotly.purge('chart')
-  dataStore.apiData = null
-  dataStore.fetchData('seaIceConcentration')
+  dataStore.apiData[endpoint] = null
+  dataStore.fetchData(endpoint)
 })
 
 watch([apiData, monthInput], async () => {
@@ -191,7 +193,7 @@ watch([apiData, monthInput], async () => {
 })
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 
@@ -238,10 +240,7 @@ onUnmounted(() => {
         populate the chart.
       </p>
 
-      <Gimme
-        :bbox="[-180, 45, 180, 90]"
-        ocean
-      />
+      <Gimme :bbox="[-180, 45, 180, 90]" ocean />
 
       <div v-if="latLng && apiData">
         <div class="parameter">

--- a/components/global/SolarRadiationCloudCoverCmip6.vue
+++ b/components/global/SolarRadiationCloudCoverCmip6.vue
@@ -1,10 +1,12 @@
 <script lang="ts" setup>
+const endpoint = 'cmip6Monthly'
+
 const placesStore = usePlacesStore()
 const mapStore = useMapStore()
 const dataStore = useDataStore()
 const runtimeConfig = useRuntimeConfig()
 
-const apiData = computed<any[]>(() => dataStore.apiData)
+const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const layers: MapLayer[] = [
@@ -152,7 +154,7 @@ const mapId = 'solar_radiation_and_cloud_cover'
 mapStore.setLegendItems(mapId, legend)
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 

--- a/components/global/StoryClimateIndicators.vue
+++ b/components/global/StoryClimateIndicators.vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+const endpoints = ['cmip6Monthly', 'cmip6MonthlyIndicators']
+
 import { usePlacesStore } from '~/stores/places'
 import { useChartStore } from '~/stores/chart'
 
@@ -59,8 +61,10 @@ onMounted(() => {
 
 onUnmounted(() => {
   placesStore.latLng = undefined
-  chartStore.inputs = undefined
-  chartStore.labels = undefined
+  endpoints.forEach(endpoint => {
+    chartStore.inputs[endpoint] = undefined
+    chartStore.labels[endpoint] = undefined
+  })
 })
 </script>
 

--- a/components/global/StoryClimateStripes1.vue
+++ b/components/global/StoryClimateStripes1.vue
@@ -1,11 +1,13 @@
 <script lang="ts" setup>
+const endpoint = 'meanAnnualTemperature'
+
 const placesStore = usePlacesStore()
 const dataStore = useDataStore()
 
 const { $Plotly, $_ } = useNuxtApp()
 import type { Data } from 'plotly.js-dist-min'
 
-const apiData = computed<Record<string, any>>(() => dataStore.apiData)
+const apiData = computed<Record<string, any>>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 const selectedCommunity = computed<CommunityValue>(
   () => placesStore.selectedCommunity
@@ -132,8 +134,8 @@ const buildChart = () => {
 
 watch(latLng, async () => {
   $Plotly.purge('chart')
-  dataStore.apiData = null
-  dataStore.fetchData('meanAnnualTemperature')
+  dataStore.apiData[endpoint] = null
+  dataStore.fetchData(endpoint)
 })
 
 watch([apiData], async () => {
@@ -141,7 +143,7 @@ watch([apiData], async () => {
 })
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 

--- a/components/global/TemperatureCmip6.vue
+++ b/components/global/TemperatureCmip6.vue
@@ -1,10 +1,12 @@
 <script lang="ts" setup>
+const endpoint = 'cmip6Monthly'
+
 const placesStore = usePlacesStore()
 const mapStore = useMapStore()
 const dataStore = useDataStore()
 const runtimeConfig = useRuntimeConfig()
 
-const apiData = computed<any[]>(() => dataStore.apiData)
+const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const layers: MapLayer[] = [
@@ -113,7 +115,7 @@ const mapId = 'tas'
 mapStore.setLegendItems(mapId, legend)
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 

--- a/components/global/WetDaysPerYear.vue
+++ b/components/global/WetDaysPerYear.vue
@@ -131,7 +131,7 @@ const buildChart = () => {
 
     let traces: Data[] = []
     let allDecades: string[] = ['']
-    chartData = dataStore.apiData.wetDaysPerYear
+    chartData = dataStore.apiData[endpoint]
 
     for (let i = 1980; i <= 2090; i += 10) {
       allDecades.push(i + '-' + (i + 9))

--- a/components/global/WetDaysPerYear.vue
+++ b/components/global/WetDaysPerYear.vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+const endpoint = 'wetDaysPerYear'
+
 import type { Data } from 'plotly.js-dist-min'
 import { precisionMean } from '~/utils/math'
 import { useMapStore } from '~/stores/map'
@@ -10,7 +12,7 @@ const mapStore = useMapStore()
 const dataStore = useDataStore()
 const runtimeConfig = useRuntimeConfig()
 
-const apiData = computed<Record<string, any>>(() => dataStore.apiData)
+const apiData = computed<Record<string, any>>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const layers: MapLayer[] = [
@@ -259,12 +261,12 @@ watch(apiData, async () => {
 
 watch(latLng, async () => {
   $Plotly.purge('chart')
-  dataStore.apiData = null
-  dataStore.fetchData('wetDaysPerYear')
+  dataStore.apiData[endpoint] = null
+  dataStore.fetchData(endpoint)
 })
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 
@@ -272,7 +274,7 @@ onUnmounted(() => {
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Wet Days Per Year</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         A wet day is defined as a day with precipitation accumulation greater
         than or equal to 1.0㎜. The map below shows the 30-year mean of wet days

--- a/components/global/WetDaysPerYear.vue
+++ b/components/global/WetDaysPerYear.vue
@@ -131,7 +131,7 @@ const buildChart = () => {
 
     let traces: Data[] = []
     let allDecades: string[] = ['']
-    chartData = dataStore.apiData
+    chartData = dataStore.apiData.wetDaysPerYear
 
     for (let i = 1980; i <= 2090; i += 10) {
       allDecades.push(i + '-' + (i + 9))

--- a/components/global/WindCmip6.vue
+++ b/components/global/WindCmip6.vue
@@ -1,10 +1,12 @@
 <script lang="ts" setup>
+const endpoint = 'cmip6Monthly'
+
 const placesStore = usePlacesStore()
 const mapStore = useMapStore()
 const dataStore = useDataStore()
 const runtimeConfig = useRuntimeConfig()
 
-const apiData = computed<any[]>(() => dataStore.apiData)
+const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
 
 const layers: MapLayer[] = [
@@ -128,7 +130,7 @@ const mapId = 'wind'
 mapStore.setLegendItems(mapId, legend)
 
 onUnmounted(() => {
-  dataStore.apiData = null
+  dataStore.apiData[endpoint] = null
 })
 </script>
 

--- a/stores/chart.ts
+++ b/stores/chart.ts
@@ -2,15 +2,21 @@ import { defineStore } from 'pinia'
 
 export const useChartStore = defineStore('chart', () => {
   let labels: Ref<
-    | HydrologyChartLabelsObj
-    | PermafrostChartLabelsObj
-    | IndicatorsCmip6ChartLabelsObj
-  > = ref(undefined)
+    Record<
+      string,
+      | HydrologyChartLabelsObj
+      | PermafrostChartLabelsObj
+      | IndicatorsCmip6ChartLabelsObj
+    >
+  > = ref({})
   let inputs: Ref<
-    | HydrologyChartInputsObj
-    | PermafrostChartInputsObj
-    | IndicatorsCmip6ChartInputsObj
-  > = ref(undefined)
+    Record<
+      string,
+      | HydrologyChartInputsObj
+      | PermafrostChartInputsObj
+      | IndicatorsCmip6ChartInputsObj
+    >
+  > = ref({})
 
   return {
     labels,

--- a/stores/data.ts
+++ b/stores/data.ts
@@ -29,14 +29,14 @@ export const useDataStore = defineStore('data', () => {
   // Use "any" type since apiData will be used to store many different types of
   // data we will get from the API for different ARDAC items.
   const apiData: Ref<Record<string, any>> = ref({})
-  const dataError: Ref<Record<string, boolean>> = ref({})
+  const dataErrors: Ref<Record<string, boolean>> = ref({})
 
   const fetchData = async (dataset: string, params: string = '') => {
     if (placesStore.latLng === undefined) {
       return // do not try
     }
     apiData.value[dataset] = null
-    dataError.value[dataset] = false
+    dataErrors.value[dataset] = false
     let url =
       runtimeConfig.public.apiUrl +
       endpoints[dataset] +
@@ -54,16 +54,16 @@ export const useDataStore = defineStore('data', () => {
       if (response.status === 200) {
         apiData.value[dataset] = data
       } else {
-        dataError.value[dataset] = true
+        dataErrors.value[dataset] = true
       }
     } catch (error) {
-      dataError.value[dataset] = true
+      dataErrors.value[dataset] = true
     }
   }
 
   return {
     fetchData,
     apiData,
-    dataError,
+    dataErrors,
   }
 })

--- a/stores/data.ts
+++ b/stores/data.ts
@@ -28,15 +28,15 @@ const endpoints: Record<string, string> = {
 export const useDataStore = defineStore('data', () => {
   // Use "any" type since apiData will be used to store many different types of
   // data we will get from the API for different ARDAC items.
-  const apiData: any = ref(null)
-  const dataError: Ref<boolean> = ref(false)
+  const apiData: Ref<Record<string, any>> = ref({})
+  const dataError: Ref<Record<string, boolean>> = ref({})
 
   const fetchData = async (dataset: string, params: string = '') => {
     if (placesStore.latLng === undefined) {
       return // do not try
     }
-    apiData.value = null
-    dataError.value = false
+    apiData.value[dataset] = null
+    dataError.value[dataset] = false
     let url =
       runtimeConfig.public.apiUrl +
       endpoints[dataset] +
@@ -52,12 +52,12 @@ export const useDataStore = defineStore('data', () => {
       const response = await fetch(url)
       const data = await response.json()
       if (response.status === 200) {
-        apiData.value = data
+        apiData.value[dataset] = data
       } else {
-        dataError.value = true
+        dataError.value[dataset] = true
       }
     } catch (error) {
-      dataError.value = true
+      dataError.value[dataset] = true
     }
   }
 


### PR DESCRIPTION
This PR adds the ability to embed multiple types of charts (charts from different datasets, or dataset families) on the same page. It does this by nesting the data store's `apiData` variable one level deeper, and converting the `dataError` variable to an object (now called `dataErrors`). `apiData` and `dataErrors` now use keys named after datasets so that data & errors for each API endpoint can be stored under their own data key to prevent the data & errors from overwriting each other as before.

The keys used are the same keys used to reference each unique Data API endpoint during the data fetch operation, defined here: https://github.com/ua-snap/ardac-explorer/blob/48face4ddc52144afd0a73fc38ecbef5e3db72bc/stores/data.ts#L5-L26

To test, please kick the tires on this a lot by loading charts on a bunch of existing "data x-ray" items to confirm that they still work as before.

You'll also notice that this page is now successfully loading two different charts from two different datasets at the same time: http://localhost:3000/item/story-climate-indicators 🎉 