### PR TITLE
Fixes router failure when in static mode in S3 bucket.

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,7 +1,8 @@
 <script lang="ts" setup>
 // Redirect S3 hashbang URLs to Nuxt URLs.
 const route = useRoute()
-onBeforeMount(() => {
+
+onMounted(() => {
   if (route.hash.substring(0, 3) == '#!/') {
     navigateTo(route.hash.substring(2))
   }
@@ -18,7 +19,6 @@ useSeoMeta({
   ogImage: metas.image,
   twitterCard: 'summary_large_image',
 })
-
 </script>
 
 <template>


### PR DESCRIPTION
This is a simple PR that fixes the router issues we were seeing when the site was on an S3 bucket website. The issue was that when we used the S3 redirection rules to add a hashbang to fool S3 into allowing an SPA, we were attempting to remove the hashbang before the vue-router was fully initialized on page load. This was resulting in NuxtLinks being broken all over the site.

This simple fix waits until everything is loaded before redirecting to the correct URL. For testing, try reloading in your browser from any tag or item, and verify that the correct redirection happens along with the ability to choose any of the tags or other NuxtLinks. 

For example, start here: http://climate.arcticdatascience.org/tag/Precipitation