### PR TITLE
Fixes the Leaflet marker in the RandomLocation map while in production

### DIFF
--- a/components/RandomLocationMap.vue
+++ b/components/RandomLocationMap.vue
@@ -2,6 +2,18 @@
 import { usePlacesStore } from '~/stores/places'
 import { useMapStore } from '~/stores/map'
 import type { LatLngTuple } from 'leaflet'
+import L from 'leaflet'
+
+// Identifies the marker icons for Leaflet when in production
+import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png'
+import markerIcon from 'leaflet/dist/images/marker-icon.png'
+import markerShadow from 'leaflet/dist/images/marker-shadow.png'
+
+L.Icon.Default.mergeOptions({
+  iconUrl: markerIcon,
+  iconRetinaUrl: markerIcon2x,
+  shadowUrl: markerShadow,
+})
 
 const placesStore = usePlacesStore()
 const mapStore = useMapStore()


### PR DESCRIPTION
This PR explicitly identifies the Leaflet markers to show the Leaflet marker in the RandomLocation map for Points & Polygons when running in production. To test this, you can comment out lines 8-16 in components/RandomLocationMap.vue and then run:

npm run generate && cd dist && python -m http.server 8080

Open http://localhost:8000 and navigate to Points and Polygons and try clicking on the random location map. You'll notice that the Leaflet marker is not present. 

Reverse the commented out code and the Leaflet marker will be available in the statically built site.