### PR TITLE
Fix CMIP6 empty chart bug

### DIFF
--- a/components/Cmip6MonthlyChart.vue
+++ b/components/Cmip6MonthlyChart.vue
@@ -113,7 +113,12 @@ const buildChart = () => {
 
         let yearMonthData = chartData[model][scenario][yearMonth]
         let value = yearMonthData[props.dataKey]
-        values.push(value * multiplier)
+
+        if (value === undefined) {
+          values.push(value)
+        } else {
+          values.push(value * multiplier)
+        }
       })
 
       // Makes chart for sea ice concentration into a line chart

--- a/components/Cmip6MonthlyChart.vue
+++ b/components/Cmip6MonthlyChart.vue
@@ -114,6 +114,8 @@ const buildChart = () => {
         let yearMonthData = chartData[model][scenario][yearMonth]
         let value = yearMonthData[props.dataKey]
 
+        // Pushing undefined is intentional to allow later logic to hide the chart
+        // when all values are undefined.
         if (value === undefined) {
           values.push(value)
         } else {


### PR DESCRIPTION
Closes #253.

This PR fixes a problem that appears on the CMIP6 Temperature charts where, if `tasmin` and `tasmax` data are not available for the selected model, it displays empty min/max temperature charts instead of hiding these charts completely.

I remembered having solved this problem once before, but it turns out this line of code that was added later had introduced the bug:

https://github.com/ua-snap/ardac-explorer/blob/ef4c729b8f8b12c553d1162727f20d114903fa39/components/Cmip6MonthlyChart.vue#L116

This line of code was multiplying `value` by `multiplier` without first checking to see if the value was `undefined`. There is already some code in place to determine if all chart values are `undefined`, and to hide the chart if so. But attempting to multiply `undefined` by a number (`multiplifer`) converts it into a `NaN`, which is not detected by the chart code. So, this fix simply checks to see if `value` is `undefined` before attempting to multiply it.

To test, run the Data API from the `add_e3sm` branch (necessarily for compatibility with the new `cmip6_monthly` coverage) while pointed at Apollo:

```
cd data-api
git checkout add_e3sm
export FLASK_APP=application.py
export API_RAS_BASE_URL=https://apollo.snap.uaf.edu/rasdaman/
pipenv run flask run
```

Then run ARDAC Explorer pointed at Apollo and your local API:

```
cd ardac-explorer
export RASDAMAN_URL=https://apollo.snap.uaf.edu/rasdaman/ows
export SNAP_API_URL=http://127.0.0.1:5000
npm run dev
```

Then check out the CMIP6 Temperature item:

http://localhost:3000/item/temperature-cmip6

Enter a community into the box and then choose the "NorESM2-MM" model. This should show only one chart, for mean temperature, and not empty min/max temperature charts. I've also tested that this fixes the same problem for the upcoming E3SM-1-1 and E3SM-2-0 models that are not part of this branch.