### PR TITLE
Switch to an available scenario if selected (or default) scenario does not exist

### DIFF
--- a/components/Cmip6MonthlyChartControls.vue
+++ b/components/Cmip6MonthlyChartControls.vue
@@ -92,10 +92,26 @@ const scenarioPresent = (value: string) => {
   }
 }
 
-watch([latLng, modelInput, scenarioInput, monthInput], async () => {
+// If the user switched the model and the selected scenario is not available,
+// revert back to the default scenario if it is available. Otherwise, pick the
+// first found scenario that is available.
+const chooseScenario = () => {
   if (!scenarioPresent(scenarioInput.value)) {
-    scenarioInput.value = defaultScenario
+    if (scenarioPresent(defaultScenario)) {
+      scenarioInput.value = defaultScenario
+    } else {
+      let possibleScenarios = Object.keys(chartStore.labels?.scenarios!)
+      possibleScenarios.forEach(scenario => {
+        if (scenarioPresent(scenario)) {
+          scenarioInput.value = scenario
+        }
+      })
+    }
   }
+}
+
+watch([latLng, modelInput, scenarioInput, monthInput], async () => {
+  chooseScenario()
   chartStore.inputs = {
     model: modelInput.value,
     scenario: scenarioInput.value,

--- a/components/Cmip6MonthlyChartControls.vue
+++ b/components/Cmip6MonthlyChartControls.vue
@@ -101,11 +101,12 @@ const chooseScenario = () => {
       scenarioInput.value = defaultScenario
     } else {
       let possibleScenarios = Object.keys(chartStore.labels?.scenarios!)
-      possibleScenarios.forEach(scenario => {
+      for (const scenario of possibleScenarios) {
         if (scenarioPresent(scenario)) {
           scenarioInput.value = scenario
+          break
         }
-      })
+      }
     }
   }
 }


### PR DESCRIPTION
Closes #252.

This PR simply adds a little more logic to make sure the "Scenario" dropdown changes to a scenario that is actually available for the selected model. Previously, we solved this by switching back to the `defaultScenario` if necessary, but with the introduction of the E3SM* models, there is no longer a particular scenario that works across all models, so this solution is a bit more dynamic to make the user interface work seamlessly.

It's hard to test this without bringing the E3SM* models in, but that has been implemented in a separate branch/PR. So, there are some extra testing steps here.

To test, run the Data API from the `add_e3sm` branch while pointed at Apollo:

```
cd data-api
git checkout add_e3sm
export FLASK_APP=application.py
export API_RAS_BASE_URL=https://apollo.snap.uaf.edu/rasdaman/
pipenv run flask run
```

Then run ARDAC Explorer pointed at Apollo and your local API, but also bring the `test_e3sm` branch into this branch for testing:

```
cd ardac-explorer
export RASDAMAN_URL=https://apollo.snap.uaf.edu/rasdaman/ows
export SNAP_API_URL=http://127.0.0.1:5000
git checkout scenario_fallback
git merge test_e3sm
npm run dev
```

Then load any CMIP6 data x-ray item ([temperature will do](http://localhost:3000/item/temperature-cmip6)) and try switching between various models, making sure to switch to E3SM-2-0 once or twice. Observe that the "Scenario" dropdown always switches to a scenario that is available for the model when necessary.