### PR TITLE
Update cmip6_monthly "swe" key to "snw" throughout code

### DIFF
--- a/components/global/SnowCmip6.vue
+++ b/components/global/SnowCmip6.vue
@@ -109,14 +109,14 @@ const prsn_layers: MapLayer[] = [
   },
 ]
 
-const swe_layers: MapLayer[] = [
+const snw_layers: MapLayer[] = [
   {
-    id: 'swe_cmip6_1950',
+    id: 'snw_cmip6_1950',
     title: 'March 1950, MIROC6',
     source: 'rasdaman',
     wmsLayerName: 'cmip6_monthly',
-    style: 'ardac_swe',
-    legend: 'swe',
+    style: 'ardac_snw',
+    legend: 'snw',
     rasdamanConfiguration: {
       dim_model: 9,
       dim_scenario: 0,
@@ -125,12 +125,12 @@ const swe_layers: MapLayer[] = [
     coastline: true,
   },
   {
-    id: 'swe_cmip6_1975',
+    id: 'snw_cmip6_1975',
     title: 'March 1975, MIROC6',
     source: 'rasdaman',
     wmsLayerName: 'cmip6_monthly',
-    style: 'ardac_swe',
-    legend: 'swe',
+    style: 'ardac_snw',
+    legend: 'snw',
     rasdamanConfiguration: {
       dim_model: 9,
       dim_scenario: 0,
@@ -139,12 +139,12 @@ const swe_layers: MapLayer[] = [
     coastline: true,
   },
   {
-    id: 'swe_cmip6_2000',
+    id: 'snw_cmip6_2000',
     title: 'March 2000, MIROC6',
     source: 'rasdaman',
     wmsLayerName: 'cmip6_monthly',
-    style: 'ardac_swe',
-    legend: 'swe',
+    style: 'ardac_snw',
+    legend: 'snw',
     rasdamanConfiguration: {
       dim_model: 9,
       dim_scenario: 0,
@@ -153,12 +153,12 @@ const swe_layers: MapLayer[] = [
     coastline: true,
   },
   {
-    id: 'swe_cmip6_2025',
+    id: 'snw_cmip6_2025',
     title: 'March 2025, MIROC6',
     source: 'rasdaman',
     wmsLayerName: 'cmip6_monthly',
-    style: 'ardac_swe',
-    legend: 'swe',
+    style: 'ardac_snw',
+    legend: 'snw',
     rasdamanConfiguration: {
       dim_model: 9,
       dim_scenario: 4,
@@ -167,12 +167,12 @@ const swe_layers: MapLayer[] = [
     coastline: true,
   },
   {
-    id: 'swe_cmip6_2050',
+    id: 'snw_cmip6_2050',
     title: 'March 2050, MIROC6',
     source: 'rasdaman',
     wmsLayerName: 'cmip6_monthly',
-    style: 'ardac_swe',
-    legend: 'swe',
+    style: 'ardac_snw',
+    legend: 'snw',
     rasdamanConfiguration: {
       dim_model: 9,
       dim_scenario: 4,
@@ -181,12 +181,12 @@ const swe_layers: MapLayer[] = [
     coastline: true,
   },
   {
-    id: 'swe_cmip6_2075',
+    id: 'snw_cmip6_2075',
     title: 'March 2075, MIROC6',
     source: 'rasdaman',
     wmsLayerName: 'cmip6_monthly',
-    style: 'ardac_swe',
-    legend: 'swe',
+    style: 'ardac_snw',
+    legend: 'snw',
     rasdamanConfiguration: {
       dim_model: 9,
       dim_scenario: 4,
@@ -195,12 +195,12 @@ const swe_layers: MapLayer[] = [
     coastline: true,
   },
   {
-    id: 'swe_cmip6_2100',
+    id: 'snw_cmip6_2100',
     title: 'March 2100, MIROC6',
     source: 'rasdaman',
     wmsLayerName: 'cmip6_monthly',
-    style: 'ardac_swe',
-    legend: 'swe',
+    style: 'ardac_snw',
+    legend: 'snw',
     rasdamanConfiguration: {
       dim_model: 9,
       dim_scenario: 4,
@@ -234,7 +234,7 @@ const legend: Record<string, LegendItem[]> = {
     },
     { color: '#006d2cff', label: '&ge; 80 kg m&#8315;&sup2; s&#8315;&sup1;' },
   ],
-  swe: [
+  snw: [
     { color: '#edf8fbff', label: '&ge;0 mm, &lt;75 mm' },
     { color: '#b2e2e2ff', label: '&ge;75 mm, &lt;150 mm' },
     { color: '#66c2a4ff', label: '&ge;150 mm, &lt;225 mm' },
@@ -272,7 +272,7 @@ mapStore.setLegendItems(mapId, legend)
           </MapLayer>
           <h4 class="title is-4 mb-3">Snow Water Equivalent</h4>
           <MapLayer
-            v-for="layer in swe_layers"
+            v-for="layer in snw_layers"
             :mapId="mapId"
             :layer="layer"
             :key="layer.id"
@@ -295,7 +295,7 @@ mapStore.setLegendItems(mapId, legend)
       <Cmip6MonthlyChartControls
         defaultModel="MIROC6"
         defaultMonth="12"
-        :datasetKeys="['prsn', 'swe']"
+        :datasetKeys="['prsn', 'snw']"
       />
       <Cmip6MonthlyChart
         label="Precipitation as Snow"
@@ -306,7 +306,7 @@ mapStore.setLegendItems(mapId, legend)
       <Cmip6MonthlyChart
         label="Snow Water Equivalent"
         units="mm"
-        dataKey="swe"
+        dataKey="snw"
       />
 
       <div v-if="latLng && apiData" class="my-6">
@@ -323,7 +323,7 @@ mapStore.setLegendItems(mapId, legend)
                 latLng.lat +
                 '/' +
                 latLng.lng +
-                '?vars=prsn,swe&format=csv'
+                '?vars=prsn,snw&format=csv'
               "
               >Download as CSV</a
             >
@@ -336,7 +336,7 @@ mapStore.setLegendItems(mapId, legend)
                 latLng.lat +
                 '/' +
                 latLng.lng +
-                '?vars=prsn,swe'
+                '?vars=prsn,snw'
               "
               >Download as JSON</a
             >

--- a/components/global/StoryArcticClimateDataNode.vue
+++ b/components/global/StoryArcticClimateDataNode.vue
@@ -527,7 +527,7 @@ onMounted(() => {
             </tr>
             <tr>
               <td>Snow water equivalent</td>
-              <td><code>swe</code></td>
+              <td><code>snw</code></td>
               <td>Monthly</td>
             </tr>
             <tr>


### PR DESCRIPTION
Closes #251.
Xref: https://github.com/ua-snap/data-api/pull/571
Xref: https://github.com/ua-snap/data-api/pull/567

This PR simply renames the `swe` CMIP6 key to `snw` throughout the code. This key was changed in the latest iteration of the `cmip6_monthly` coverage. See https://github.com/ua-snap/data-api/pull/567 (near the end of the PR description) for details.

I've also copied the`cmip6_monthly` coverage's `ardac_swe` WMS style to a new `ardac_snw` style on Apollo with the same WCPS query + color map. I'll create a PR for this in the rasdaman-ingest repo soon.

To test, run both the Data API and ARDAC Explorer from their respective `cmip6_snw_key` branches:

```
cd data-api
export FLASK_APP=application.py
export API_RAS_BASE_URL=https://apollo.snap.uaf.edu/rasdaman/
pipenv run flask run
```

```
cd ardac-explorer
export SNAP_API_URL=http://127.0.0.1:5000
export RASDAMAN_URL=https://apollo.snap.uaf.edu/rasdaman/ows
git checkout cmip6_snw_key
npm run dev
```

Then go here: http://localhost:3000/item/snow-cmip6 and:

- confirm that the "Snow Water Equivalent" map layers load as expected
- enter a location into the place selector and confirm that the "Snow Water Equivalent" chart loads