### PR TITLE
Updates bounding box of temperature stripes to match the coverage's bounding box

### DIFF
--- a/components/global/StoryClimateStripes2.vue
+++ b/components/global/StoryClimateStripes2.vue
@@ -468,7 +468,7 @@ onUnmounted(() => {
         lat/long below to get climate stripes derived from climate model data.
       </p>
 
-      <Gimme :bbox="[-180, 50, 180, 90]" />
+      <Gimme :bbox="[-180, 50.5, 180, 90]" />
       <div v-if="apiData">
         <div>
           <div class="parameter mb-5">


### PR DESCRIPTION
Charlie identified that the coverage in Zeus for both the anomalies and the baseline coverages starts at 50.5 degrees latitude, and some of the places that were being pulled in by the Gimme text field were giving 422 errors due to being outside of the coverage.

An example of this is Aguanish in Quebec. Try getting the temperature stripes for Aguanish in the development site and on this branch. You should no longer be able to get anything that is below the southern bounding box of the coverage.