### PR TITLE
Give user heads-up that chart loading can take several minutes

### DIFF
--- a/components/LoadIndicator.vue
+++ b/components/LoadIndicator.vue
@@ -21,6 +21,7 @@ const anyDataErrors = computed(() => {
 
 <template>
   <div v-if="placesStore.latLng && !anyApiData && !anyDataErrors">
+    <p>Hang on, this could take a few minutes!</p>
     <progress class="progress" />
   </div>
 </template>


### PR DESCRIPTION
As mentioned in Slack yesterday, this PR adds a line of text above the loading indicator saying:

> Hang on, this could take a few minutes!

This is the same text we use in Northern Climate Reports. It applies to all ARDAC items with a place selector (i.e., all data x-ray items, climate stripes, etc.) since any item that loads a chart can potentially take a while.

To review, confirm that the text appears after a place has been entered, and confirm that the message goes away after the chart has loaded.