### PR TITLE
Provide message to user if no communities are found with given substring

### DIFF
--- a/components/Gimme.vue
+++ b/components/Gimme.vue
@@ -62,7 +62,7 @@ onMounted(() => {
           )
         }
         if (results.length === 0) {
-          fieldMessage.value = 'No communities found with that substring.'
+          fieldMessage.value = '⚠️ Sorry, no matching communities within the extent of this dataset were found.'
         } else {
           fieldMessage.value = ''
         }
@@ -305,5 +305,9 @@ onUnmounted(() => {
 
 #gimme {
   background-image: none;
+}
+
+.help {
+  font-size: 1.25rem;
 }
 </style>

--- a/components/Gimme.vue
+++ b/components/Gimme.vue
@@ -61,6 +61,11 @@ onMounted(() => {
               c.latitude <= bbox[3]
           )
         }
+        if (results.length === 0) {
+          fieldMessage.value = 'No communities found with that substring.'
+        } else {
+          fieldMessage.value = ''
+        }
         return results
       },
       keys: ['name'],


### PR DESCRIPTION
Gives a message below the Gimme box if no communities were found containing the given substring. 

To test, start your local API on the main branch and point this branch at it:
`export SNAP_API_URL=http://localhost:5000`

Go to any X-ray item and type in a bad substring and note that the Gimme box returns a message below it that states that "No communities found with that substring."

Closes #283 