### PR TITLE
Required change to allow passthrough results from the API without additional filtering by autocomplete library.

### DIFF
--- a/components/Gimme.vue
+++ b/components/Gimme.vue
@@ -63,7 +63,11 @@ onMounted(() => {
         }
         return results
       },
-      keys: ['name', 'alt_name'],
+      keys: ['name'],
+    },
+    searchEngine: (query: string, record: any) => {
+      // Required for the autocomplete library to not filter results
+      return record
     },
     threshold: 3,
     debounce: 200,


### PR DESCRIPTION
This PR modifies the "search engine" portion of the autocomplete.js library so that the results are passed through unfiltered by the library. The issue we were seeing is that with the changes to the API to allow for fuzzy matching of results, the autocomplete library was filtering those results a second time for exact character matches and removing the fuzzy results. 

All this does is creates a passthrough for that section of the library so that the results from the API and data.src sections of the configuration are passed through the the front end without additional filtering. 

To test, set your local API to this branch: https://github.com/ua-snap/data-api/pull/613
`export SNAP_API_URL=http://localhost:5000`
`npm run dev`