### PR TITLE
Removes Umami events from NuxtLinks to allow for client-side routing.

### DIFF
--- a/components/Item/Brief.vue
+++ b/components/Item/Brief.vue
@@ -11,11 +11,7 @@ let item = store.itemBySlug(props.slug)
 <template>
   <div v-if="store.itemHasComponent(item)" class="item brief">
     <Tag v-if="showTag" :tag="item.tags[0]" />
-    <NuxtLink
-      :to="{ name: 'item-slug', params: { slug: item.slug } }"
-      data-umami-event="Item Clicked"
-      :data-umami-event-title="item.title"
-    >
+    <NuxtLink :to="{ name: 'item-slug', params: { slug: item.slug } }">
       <h3 class="title is-5" v-html="item.title"></h3>
     </NuxtLink>
   </div>

--- a/components/Item/Text.vue
+++ b/components/Item/Text.vue
@@ -11,11 +11,7 @@ let item = store.itemBySlug(props.slug)
 <template>
   <div v-if="store.itemHasComponent(item)" class="item text">
     <Tag v-if="showTag" :tag="item.tags[0]" />
-    <NuxtLink
-      :to="{ name: 'item-slug', params: { slug: item.slug } }"
-      data-umami-event="Item Clicked"
-      :data-umami-event-title="item.title"
-    >
+    <NuxtLink :to="{ name: 'item-slug', params: { slug: item.slug } }">
       <h3 class="title is-4" v-html="item.title"></h3>
       <p v-html="item.blurb" class="mb-4" />
     </NuxtLink>

--- a/components/Item/TextPicture.vue
+++ b/components/Item/TextPicture.vue
@@ -11,11 +11,7 @@ let item = store.itemBySlug(props.slug)
 <template>
   <div v-if="store.itemHasComponent(item)" class="item text-picture">
     <Tag v-if="showTag" :tag="item.tags[0]" />
-    <NuxtLink
-      :to="{ name: 'item-slug', params: { slug: item.slug } }"
-      data-umami-event="Item Clicked"
-      :data-umami-event-title="item.title"
-    >
+    <NuxtLink :to="{ name: 'item-slug', params: { slug: item.slug } }">
       <h3 class="title is-4" v-html="item.title"></h3>
       <p v-html="item.blurb" class="mb-4" />
       <figure v-if="item.image" class="image is-5by4">

--- a/components/Tagbar.vue
+++ b/components/Tagbar.vue
@@ -10,95 +10,40 @@ const expandedText = computed(() => {
   <div class="tagbar">
     <ul>
       <li>
-        <NuxtLink
-          data-umami-event="Tagbar Clicked"
-          data-umami-event-tag="Climate"
-          to="/tag/Climate"
-          >Climate</NuxtLink
-        >
+        <NuxtLink to="/tag/Climate">Climate</NuxtLink>
       </li>
       <li>
-        <NuxtLink
-          to="/tag/Precipitation"
-          data-umami-event="Tagbar Clicked"
-          data-umami-event-tag="Precipitation"
-          >Precipitation</NuxtLink
-        >
+        <NuxtLink to="/tag/Precipitation">Precipitation</NuxtLink>
       </li>
       <li>
-        <NuxtLink
-          to="/tag/Wildfire"
-          data-umami-event="Tagbar Clicked"
-          data-umami-event-tag="Wildfire"
-          >Wildfire</NuxtLink
-        >
+        <NuxtLink to="/tag/Wildfire">Wildfire</NuxtLink>
       </li>
       <li>
-        <NuxtLink
-          to="/tag/Cryosphere"
-          data-umami-event="Tagbar Clicked"
-          data-umami-event-tag="Cryosphere"
-          >Cryosphere</NuxtLink
-        >
+        <NuxtLink to="/tag/Cryosphere">Cryosphere</NuxtLink>
       </li>
       <li>
-        <NuxtLink
-          to="/tag/Permafrost"
-          data-umami-event="Tagbar Clicked"
-          data-umami-event-tag="Permafrost"
-          >Permafrost</NuxtLink
-        >
+        <NuxtLink to="/tag/Permafrost">Permafrost</NuxtLink>
       </li>
       <li @click="expanded = !expanded" class="more" v-html="expandedText"></li>
     </ul>
     <ul v-show="expanded">
       <li>
-        <NuxtLink
-          to="/tag/Hydrology"
-          data-umami-event="Tagbar Clicked"
-          data-umami-event-tag="Hydrology"
-          >Hydrology</NuxtLink
-        >
+        <NuxtLink to="/tag/Hydrology">Hydrology</NuxtLink>
       </li>
       <li>
-        <NuxtLink
-          to="/tag/Terrestrial"
-          data-umami-event="Tagbar Clicked"
-          data-umami-event-tag="Terrestrial"
-          >Terrestrial</NuxtLink
-        >
+        <NuxtLink to="/tag/Terrestrial">Terrestrial</NuxtLink>
       </li>
       <li>
-        <NuxtLink
-          to="/tag/Programming"
-          data-umami-event="Tagbar Clicked"
-          data-umami-event-tag="Programming"
-          >Programming</NuxtLink
-        >
+        <NuxtLink to="/tag/Programming">Programming</NuxtLink>
       </li>
       <li>
-        <NuxtLink
-          to="/tag/Temperature"
-          data-umami-event="Tagbar Clicked"
-          data-umami-event-tag="Temperature"
-          >Temperature</NuxtLink
-        >
+        <NuxtLink to="/tag/Temperature">Temperature</NuxtLink>
       </li>
       <li>
-        <NuxtLink
-          to="/tag/Lightning"
-          data-umami-event="Tagbar Clicked"
-          data-umami-event-tag="Lightning"
-          >Lightning</NuxtLink
-        >
+        <NuxtLink to="/tag/Lightning">Lightning</NuxtLink>
       </li>
       <li>
-        <NuxtLink
-          to="/tag/CMIP6"
-          data-umami-event="Tagbar Clicked"
-          data-umami-event-tag="CMIP6"
-          >CMIP6</NuxtLink
-        >
+        <NuxtLink to="/tag/CMIP6">CMIP6</NuxtLink>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
This PR removes the Umami analytics special parameters from all `NuxtLink` components to allow for the website when accessed from its main site to act as a single page application. Without this change, we were seeing the `NuxtLink` client-side routing being intercepted by Umami and sent as a plain anchor link route, reloading the page on each click. This change will only impact the site at https://arcticdatascience.org as we explicitly tell Umami to only track from that URL.

While this change does mean that we don't have explicit events shown in Umami, we still get the page views which shows the same information.