### PR TITLE
Removes link to "run this notebook online"

### DIFF
--- a/components/NotebookTemplate.vue
+++ b/components/NotebookTemplate.vue
@@ -24,11 +24,6 @@ const props = defineProps(['jupyterlabUrl', 'githubUrl'])
           <div class="is-size-5">
             <ul>
               <li>
-                <NuxtLink :to="jupyterlabUrl"
-                  >&#x2192; run this notebook online</NuxtLink
-                >
-              </li>
-              <li>
                 <NuxtLink :to="githubUrl"
                   >&#x2192; download this notebook from GitHub</NuxtLink
                 >

--- a/components/global/NotebookPrecipPoly.vue
+++ b/components/global/NotebookPrecipPoly.vue
@@ -67,9 +67,6 @@
     <div class="content is-size-5">
       <ul>
         <li>
-          <a href="https://notebooks.earthmaps.io">Run this notebook online</a>
-        </li>
-        <li>
           <a
             href="https://github.com/ua-snap/ardac-toolbox/blob/main/notebooks/daymet_access.ipynb"
             >Access source code on Github</a


### PR DESCRIPTION
Test: pick "see more" from the menu-tag-bar, pick Programming, go to any (implemented) programming item.  Observe that with this PR, there's no "run this notebook online" link at the upper right of the item or at the bottom of any of them.

When this ticket is reviewed for release notes, include the task of turning off the notebook server and surplussing it as well.